### PR TITLE
Remove URLless link (#11)

### DIFF
--- a/docs/vega-chain.md
+++ b/docs/vega-chain.md
@@ -1,33 +1,34 @@
-# Vega Chain 
- ## Staking
-Vega runs on a delegated proof of stake blockchain. Participants who hold a balance of VEGA, the governance asset, can stake that asset on the network by nominating their tokens to one or more validators that they trust to help secure the network. 
+# Vega Chain
 
- ### Simple staking (restricted mainnet) 
-Validators and stakers both receive incentives from the network, depending on various factors, including how much stake is nominated. 
- 
-Staking requires the combined action of: associating VEGA tokens (or fractions of a token) to the Vega staking bridge contract; and using the token(s) to nominate one or more validators. 
+## Staking
+Vega runs on a delegated proof of stake blockchain. Participants who hold a balance of VEGA, the governance asset, can stake that asset on the network by nominating their tokens to one or more validators that they trust to help secure the network.
+
+### Simple staking (restricted mainnet)
+Validators and stakers both receive incentives from the network, depending on various factors, including how much stake is nominated.
+
+Staking requires the combined action of: associating VEGA tokens (or fractions of a token) to the Vega staking bridge contract; and using the token(s) to nominate one or more validators.
 
 A VEGA token (or a fraction thereof) is either unassociated or associated to a validator:
 
-- Unassociated: The tokenholder is free to do with the token as they want, but cannot delegate it (the default) 
+- Unassociated: The tokenholder is free to do with the token as they want, but cannot delegate it (the default)
 - Associated: The token is locked in the smart contract, and can be used inside the delegation system, but must be unassociated to withdraw it
 
-Both unassociated and associated tokens can be used to vote on governance actions. 
+Both unassociated and associated tokens can be used to vote on governance actions.
 
 << tip: VEGA tokenholders can associate their tokens and then nominate validators to receive rewards, using token.vega.xyz, or CoinList, depending on how they acquired their tokens. All tokens, whether locked in the vesting contract or unlocked, can be used for staking. >>
 
 #### Smart contract & staking bridge interactions
 
-All actions regarding staking are initiated by the Vega staking bridge contract (not by the Vega protocol). 
+All actions regarding staking are initiated by the Vega staking bridge contract (not by the Vega protocol).
 
-Vega will be made aware of how many tokens a given party has associated through bridge events, and when those same tokens are unassociated, a corresponding event is emitted (below). Vega uses this information to keep track of total nominatable stake, unnominated stake, stake per validator, stake per validator marked for nomination in the next epoch, and total stake. 
+Vega will be made aware of how many tokens a given party has associated through bridge events, and when those same tokens are unassociated, a corresponding event is emitted (below). Vega uses this information to keep track of total nominatable stake, unnominated stake, stake per validator, stake per validator marked for nomination in the next epoch, and total stake.
 
-```  
+```
 event Stake_Deposited(address indexed user, uint256 amount, bytes32 vega_public_key)
 event Stake_Removed(address indexed user, uint256 amount)
 ```
 
-Staked assets will appear in a user's staking account once the Vega network sees the relevant `Stake_Deposited` event(s) with enough confirmations (defined by network parameter XXXXX). Vega will listen for `Stake_Deposited` events from the staking bridge and ERC20 vesting contracts (link) and increase the balance in the appropriate party's stake account by the amount deposited each time new stake is deposited. 
+Staked assets will appear in a user's staking account once the Vega network sees the relevant `Stake_Deposited` event(s) with enough confirmations (defined by network parameter XXXXX). Vega will listen for `Stake_Deposited` events from the staking bridge and ERC20 vesting contracts (link) and increase the balance in the appropriate party's stake account by the amount deposited each time new stake is deposited.
 
 The majority of the logic for staking VEGA tokens exists on the Ethereum network as Solidity contracts. They conform to specific interfaces, defined below, and emit certain events, This ensures staking for both normal ERC20 tokens and tokens locked in the vesting contract is possible.
 
@@ -61,7 +62,7 @@ Functions:
 
 **ERC20 vesting contract**
 
-The ERC20 vesting contract supports staking the tokens it holds. 
+The ERC20 vesting contract supports staking the tokens it holds.
 
 Attempts to redeem vested tokens will fail if there are not sufficient tokens held on behalf of the sender address that are not staked. The sender must first unstake tokens before they can be redeemed.
 
@@ -71,7 +72,7 @@ Functions:
 * `stake_tokens(uint256 amount, bytes32 vega_public_key)` allows staking of tokens held by the contract on behalf of an address
 	* Requires that the vesting contract holds at least `amount` (HOW IS THIS AMOUNT DEFINED?) governance tokens, that are currently not staked, on behalf of the sender address (they will be redeemable by sender once vested)
 	* Allows staking of both unvested (locked) tokens and vested tokens that are not yet redeemed
-* `remove_stake(uint256 amount, bytes32 vega_public_key)` 
+* `remove_stake(uint256 amount, bytes32 vega_public_key)`
 	* Requires that the vesting contract holds at least `amount` governance tokens, that are currently staked to the specified Vega public key, on behalf of the sender address (i.e. they will be redeemable by sender once vested)
 	* 	* Emits `Stake_Deposited` events
 	* Emits `Stake_Removed` events
@@ -79,7 +80,7 @@ Functions:
 #### Delegating and undelegating  (WIP)
 Any locked and undelegated stake can be delegated at any time by putting a delegation-message on the chain. However, the delegation only becomes valid towards the next epoch, though it can be undone through undelegate.
 
-Once Vega is aware of locked tokens, the users will have an account with the balance reflecting how many tokens were locked. At this point, the user can submit a transaction to use their tokens to nominate validators. 
+Once Vega is aware of locked tokens, the users will have an account with the balance reflecting how many tokens were locked. At this point, the user can submit a transaction to use their tokens to nominate validators.
 
 ```proto
 message Delegate {
@@ -107,7 +108,7 @@ Users can remove stake by submitting an `undelegate` transaction. The tokens wil
 At the top level, `Stake_Deposited` simply adds `amount` of tokens to the account of the user associated with the `user`. Likewise, the `Stake_Removed` event subtracts the `amount` of tokens from their account.
 
 - If the `Stake_Removed` amount of tokens is higher than the balance of said user, something went seriously wrong somewhere. This is a good time to panic.
-- If the amount is higher than the amount of undelegated stake, the missing amount must be freed using the undelegate function (see section above about bridge contract interaction). There is currently no rule how to choose this; 
+- If the amount is higher than the amount of undelegated stake, the missing amount must be freed using the undelegate function (see section above about bridge contract interaction). There is currently no rule how to choose this;
 
 *Option-1*
 A first heuristic would be to take from the highest delegation first and then go down, e.g.
@@ -131,33 +132,33 @@ _Undelegate towards the end of the epoch_
 _Undelegate Now_
 `UndelegateNow`
 The action can be announced at any time and is executed immediately following the block it is announced in.
-The user is marked to not receive any reward from the validator in that epoch. The reward should instead go into the [on-chain treasury account for that asset](). The stake is marked as free for the delegator, but is not yet removed from the validator stake (this happens at the end of the epoch).
+The user is marked to not receive any reward from the validator in that epoch. The reward should instead go into the `on-chain treasury account for that asset` (TODO: add link). The stake is marked as free for the delegator, but is not yet removed from the validator stake (this happens at the end of the epoch).
 
 ### Auto [Un]delegation
-- A party become eligible to participate in auto delegation once they have manually delegated (nominated) 95%+ of the association. 
-- Once entering auto delegation mode, any un-nominated associated tokens will be automatically distributed according to the current validator nomination of the party maintaining the same proportion. 
+- A party become eligible to participate in auto delegation once they have manually delegated (nominated) 95%+ of the association.
+- Once entering auto delegation mode, any un-nominated associated tokens will be automatically distributed according to the current validator nomination of the party maintaining the same proportion.
 - Edge cases:
-  - If a party has entered auto delegation mode, and their association has increased it should be automatically distributed for the epoch following the increase of association. However, if during the same epoch the party requests to execute manual delegation, no automatic delegation will be done in that epoch. If there is still un-nominated association in the next epoch, it will be automatically distributed. 
-  - If a party qualifies for auto delegation and has un-nominated association, however the party requests to undelegate (either during the epoch or at the end of the epoch) - they exit auto delegation mode. The rationale here is that they probably want to do some rearrangement of their nomination and we give them a chance to do so. Once the party reached more than x% of nomination again, they would enter auto delegation mode again and any future un-nominated association will be automatically distributed. 
-  - When distributing the newly available association according to the current validators nomination of the party, if validator A should get X but can only accept X - e (due to max per validator constraint), Vega will not try to distribute e between the other validators and will try to distribute it again in the next round. 
-- Auto undelegation - whenever the party dissociates tokens, their nomination must be updated such that their maximum nomination reflects the association. 
+  - If a party has entered auto delegation mode, and their association has increased it should be automatically distributed for the epoch following the increase of association. However, if during the same epoch the party requests to execute manual delegation, no automatic delegation will be done in that epoch. If there is still un-nominated association in the next epoch, it will be automatically distributed.
+  - If a party qualifies for auto delegation and has un-nominated association, however the party requests to undelegate (either during the epoch or at the end of the epoch) - they exit auto delegation mode. The rationale here is that they probably want to do some rearrangement of their nomination and we give them a chance to do so. Once the party reached more than x% of nomination again, they would enter auto delegation mode again and any future un-nominated association will be automatically distributed.
+  - When distributing the newly available association according to the current validators nomination of the party, if validator A should get X but can only accept X - e (due to max per validator constraint), Vega will not try to distribute e between the other validators and will try to distribute it again in the next round.
+- Auto undelegation - whenever the party dissociates tokens, their nomination must be updated such that their maximum nomination reflects the association.
 
- ### ERC20 governance and staking token (restricted mainnet)
+### ERC20 governance and staking token (restricted mainnet)
 
-Vega uses an ERC20 token called VEGA for governance. This includes nominating validators, and creating and voting on governance proposals. 
+Vega uses an ERC20 token called VEGA for governance. This includes nominating validators, and creating and voting on governance proposals.
 
 << tip >> A party's VEGA tokens must first be recognised against a Vega public key before they can be used on the Vega network for governance and staking. << tip >>
 
-The VEGA token system *(better word?)* and contract allows VEGA to be staked to a Vega public key without any action on the Vega network, and without putting the tokens under the control of the Vega network. 
+The VEGA token system *(better word?)* and contract allows VEGA to be staked to a Vega public key without any action on the Vega network, and without putting the tokens under the control of the Vega network.
 
-Using this approach means: 
+Using this approach means:
 - Locked (unvested) tokens can be staked. Both staking and unstaking are controlled entirely on the Ethereum side, and staked balances are recognised on the Vega network by listening for `Stake_*` events that can be emitted by any contract that's recognised by the network. This makes it possible to implement staking (nomination and denomination) functionality into the token vesting contract in addition to the ERC20 staking contract.
 - Any attacker who gains control of, or is able to exploit, the Vega network will be unable to steal staked VEGA tokens. Even if an attacker was able to take over the network, the tokenholders would remain unaffected and could fix the issue and relaunch the network by delegating to new validators.
 
 
- ## Validators
- ## Tendermint consensus
-  ### Transaction and sequencing
-  ### Transaction ordering
- ## Fast syncing
- ## Fairness (Wendy) 
+## Validators
+## Tendermint consensus
+### Transaction and sequencing
+### Transaction ordering
+## Fast syncing
+## Fairness (Wendy)


### PR DESCRIPTION
This small PR:
* removes leading and trailing whitespace
* removes a markdown link (`[txt](URL)`) that was missing a URL

Closes #11 