### PR TITLE
Add validator score details to concepts

### DIFF
--- a/docs/concepts/vega-chain.md
+++ b/docs/concepts/vega-chain.md
@@ -13,19 +13,8 @@ Vega runs on a delegated proof of stake blockchain. Participants -- validators a
 
 Everyone participating in keeping the network secure, robust and reliable, including nominators, is rewarded for keeping the network running. Not meeting the requirements of running the network can lead to penalties. 
 
-### Penalties 
-Validators that don't meet the requirements or prove to be bad actors will have rewards withheld. Nominators of a validator that doesn't meet the requirements will also receive fewer (or no) rewards. A validator's performance is calculated based on their **validator score**, and in the future their **performance score**. 
-
-### Validator score
-The validator score is calculated based on how much stake a validator has. If, at the end of an epoch, a validator does not have sufficient self-stake or has overall too much stake, then their validator score will be lowered. 
-
-<!--
-### ***Further reading***
-Link to spec for staking and validator rewards when publicly available. (valpol)
--->
-
 ### VEGA token
-Vega uses the VEGA ERC20 token for governance, which includes nominating validators, and creating and voting on governance proposals.
+Vega uses the VEGA ERC20 token for governance, which includes nominating validators to run nodes, and creating and voting on governance proposals.
 
 A VEGA token (or fraction) can be either unassociated or associated with a Vega key:
 
@@ -37,85 +26,6 @@ A VEGA token (or fraction) can be either unassociated or associated with a Vega 
 :::info
 A user's VEGA tokens must first be associated with a Vega key before they can be used for governance and staking.
 :::
-
-### Staking on Vega 
-Vega networks use the ERC20 token VEGA for staking. Staking requires the combined action of associating VEGA tokens (or fractions of a token) to the Vega staking bridge contract; and using those token(s) to nominate one or more validators. 
-
-**Epochs** 
-An epoch is a time period during which staking changes can be announced and then implemented. Changes that are announced in one epoch will only be executed in the following epoch (excepting 'un-nominate now' - see below). The length of an epoch is set by the network parameter `validators.epoch.length`. 
-
-### Nominating validators
-Using tokens to nominate validators keeps the decentralised network functioning. 
-
-Tokenholders can nominate validators to encourage a diverse set of reliable nodes running the network, and to give the community the opportunity to disincentivise and/or remove bad validators.
-
-When a tokenholder chooses a validator (or validators) to nominate with their tokens, the amount is immediately subtracted from their available balance, and is used at the start of the next epoch to actively nominate those validator(s). 
-
-:::info
-VEGA tokenholders can use [token.vega.xyz](https://token.vega.xyz) to associate their tokens and nominate validators. A Vega Wallet and Ethereum wallet are both required. CoinList custodial users should confirm with CoinList how staking works for them.
-:::
-
-### Maximum stake per validator
-Each validator has a maximum amount of stake that they can accept. During restricted mainnet, this will be the same amount for all validators. 
-
-The max stake per validator equation includes all nominations and un-nominations requested in the next epoch, and the current epoch's active nominations, divided by the optimal number of validators. The optimal number of validators is defined using network parameters. 
-
-It is calculated as: 
-
-```
-max stake per validator = (
-current total stake across all validators 
-   - total requested un-nominated stake 
-   + total requested nominated stake) 
-/ 
-(max(
-    reward.staking.delegation.minValidators, 
-    (number of validators 
-        / reward.staking.delegation.competitionLevel
-    )
-)
-```
-
-### Automatic nomination
-Automatic nomination is triggered when an individual tokenholder has manually nominated 95%+ of their associated tokens. At that point, any newly associated tokens will automatically be nominated to the same validators, in the same proportion.
-
-Exceptions to automatic nomination: 
-* If, ahead of the next epoch a participant uses their available tokens to nominate validators manually, that takes precedence over automatic nomination. 
-* For the epoch after un-nominating validators (see below), tokens are not auto-nominated, to provide time to change the delegation / remove tokens.  
-
-### Un-nominating validators
-Participants can remove their nomination at the end of an epoch, or immediately. The un-nominated tokens will be restored back to the participant's associated token balance.
-
-**Un-nominate towards the end of the epoch** 
-
-A participant can un-nominate towards the end of the current epoch, which means the stake is not used for the validator from the following epoch. 
-
-The action is announced in the next available block of the same epoch, but the nominator keeps their nomination active until the last block of that epoch. At that point, the tokens are returned. The nominator cannot move those tokens before the epoch ends.
-
-**Un-nominate now**
-
-A participant can choose to un-nominate at any time, and the action is executed immediately following the block it is announced in (within the same epoch). 
-
-The participant will not receive any rewards from the validator in that epoch. The tokens are marked as available to the participant.
-
-### Staking rewards
-Validators and nominators both receive incentives from the network, depending on factors including how much stake is nominated. 
-
-**To be considered for staking rewards, a participant must associate VEGA to a Vega key and nominate one or more validators.**
-
-For restricted mainnet, rewards are distributed among validators in proportion to their total stake. The total stake includes a validator's own stake and the tokens nominated to that validator. 
-
-At the end of each epoch, reward payments are calculated per active validator, and then some of that reward is divided between their nominators. The proportion that goes to nominators is defined by the network parameter `reward.staking.delegation.delegatorShare`. 
-
-:::note Further reading
-Read the [staking rewards](https://github.com/vegaprotocol/specs/blob/main/protocol/0058-simple-POS-rewards.md) spec for full details for how rewards are calculated and will be in future iterations. 
-:::
- 
-:::info
-VEGA tokenholders can use [token.vega.xyz](https://token.vega.xyz) to associate their tokens and nominate validators to receive rewards. CoinList
-custodial users should confirm with CoinList how staking works for them.
-:::
-
 
 ### Bridges used for staking
 Because VEGA is an ERC20 token, all actions regarding staking are initiated on Ethereum, rather than on the Vega protocol. This allows VEGA to be staked to a Vega public key without any action on the Vega network, and without putting the tokens under the control of the Vega network.
@@ -129,18 +39,177 @@ Whether tokens are unlocked or locked, the bridge events make the Vega network o
 All events (including the above, plus stake per validator and others) are only registered after a certain number of block confirmations, as defined by the network parameter `blockchains.ethereumConfig`. 
 
 :::note Further reading
-The staking bridge contracts can be found on the [Staking Bridge repository](https://github.com/vegaprotocol/Staking_Bridge) on GitHub.
+**[Staking Bridge contracts](https://github.com/vegaprotocol/Staking_Bridge)** - on Vega's staking bridge GitHub repository.
 :::
 
 ### Spam protection
-To avoid fragmentation or spam, there is minimum delegateable stake that defines the smallest unit (fractions of) tokens that can be used for delegation, defined by the network parameter `validators.delegation.minAmount`. 
+To avoid fragmentation or spam, there is a minimum delegateable stake that defines the smallest unit (fractions of) tokens that can be used for nomination, defined by the network parameter `validators.delegation.minAmount`. 
 
-## Validators
-The Vega network is operated by a number of independent validators. Validators are responsible for agreeing on the order of transactions and creating new blocks so that all nodes can agree on the state of the network. 
+## Staking on Vega
+Vega networks use the ERC20 token VEGA for staking. Staking requires the combined action of associating VEGA tokens (or fractions of a token) to the Vega staking bridge contract; and using those token(s) to nominate one or more validators. 
 
-In restricted mainnet, all validators effectively have the same stake, so all are selected an equal number of times to validate a block. Thus rewards will be equal between them, assuming they all continue to function. 
+**Epochs**
+An epoch is a time period during which staking changes can be announced and then implemented. Changes that are announced in one epoch will only be executed in the following epoch (excepting 'un-nominate now' - see below). The length of an epoch is set by the network parameter `validators.epoch.length`. 
+
+### Nominating validators
+Using tokens to nominate validators keeps the decentralised network functioning. 
+
+Tokenholders can nominate validators to encourage a diverse set of reliable nodes running the network, and to give the community the opportunity to disincentivise and/or remove bad validators. Tokenholders who nominate validators are also eligible for rewards. [**Read more about rewards for staking.**](/docs/concepts/vega-chain#rewards)
+
+When a tokenholder chooses a validator (or validators) to nominate with their tokens, the amount is immediately subtracted from their available balance, and is used at the start of the next epoch to actively nominate those validator(s). 
+
+:::info
+VEGA tokenholders can use **[token.vega.xyz](https://token.vega.xyz)** to associate their tokens and nominate validators. A Vega Wallet and Ethereum wallet are both required. CoinList custodial users should confirm with CoinList how staking works for them.
+:::
+
+### Automatic nomination
+Automatic nomination is triggered when an individual tokenholder has manually nominated 95%+ of their associated tokens. At that point, any newly associated tokens will automatically be nominated to the same validators, in the same proportion.
+
+Exceptions to automatic nomination: 
+* If, ahead of the next epoch a participant uses their available tokens to nominate validators manually, that takes precedence over automatic nomination. 
+* For the epoch after un-nominating validators (see below), tokens are not auto-nominated, to provide time to change the delegation / remove tokens.  
+
+### Un-nominating validators
+Participants can remove their nomination at the end of an epoch, or immediately. The un-nominated tokens will be restored back to the participant's associated token balance.
+
+**Un-nominate towards the end of the epoch**
+
+A participant can un-nominate towards the end of the current epoch, which means the stake is not used for the validator from the following epoch. 
+
+The action is announced in the next available block of the same epoch, but the nominator keeps their nomination active until the last block of that epoch. At that point, the tokens are returned. The nominator cannot move those tokens before the epoch ends.
+
+**Un-nominate now**
+
+A participant can choose to un-nominate at any time, and the action is executed immediately following the block it is announced in (within the same epoch). 
+
+The participant will not receive any rewards from the validator in that epoch. The tokens are marked as available to the participant.
+
+## Staking rewards & penalties
+
+### Rewards
+Validators and nominators both receive incentives from the network, depending on factors including how much stake is nominated. 
+
+**To be considered for staking rewards, a tokenholder must associate VEGA to a Vega key and nominate one or more validators.**
+
+In each epoch, rewards are distributed among validators in proportion to the number of tokens they represent (i.e., their total stake)*. The total stake includes a validator's own stake and the tokens nominated to that validator. Of this reward, a fixed amount is distributed among the tokenholders the validator represents. Currently that value is 88.3%; though validators can vote to change that value.
+
+*This is to a maximum number, after which their proportion no longer increases. 
+
+The reward scheme uses a linear reward curve - the reward per staked token is independent of the behaviour of other tokenholders.  This holds for validators as well, with the exception of the a maximum amount of stake an individual validator can take on. [Read more about the risks of over-staked validators.](/docs/concepts/vega-chain#too-much-stake)
+
+At the end of each epoch, reward payments are calculated per active validator, and then some of that reward is divided between their nominators. 
+ 
+:::info
+VEGA tokenholders can use **[token.vega.xyz](https://token.vega.xyz)** to associate their tokens and nominate validators to receive rewards. CoinList
+custodial users should confirm with CoinList how staking works for them.
+:::
+
+#### Reward calculations [WIP]
+
+== The proportion that goes to nominators is defined by the network parameter `reward.staking.delegation.delegatorShare`. 
+
+Two parameters are relevant to the calculation of staking rewards, as well as two network properties.
+
+`MinVal` is the minimum tolerable number of validators. If the number of validators goes below this value, the maximum size of a validator will shrink to the point that tokenholders are motivated to bring in more validators.
+
+`CompetitionLevel` defines how large validators can get relative to each other. The current value (3.1) means that for all validators to reach their optimal revenue, a total of 310% of staked tokens would be required, leaving motivation for most validators to obtain more stake.
+
+The other two parameters are the total amount of staked tokens, as well as the number of validators (currently 13).
+
+```
+func calcValidatorScore(normalisedValStake, minVal, compLevel, numVal float64) float64 {
+a := math.Max(minVal, numVal/compLevel)
+return math.Min(normalisedValStake, 1/a)
+}
+```
+
+With the current parameters, the maximum delegation a validator can represent is 20% of the total number of delegated tokens, and this value will stay the same up to 15 validators - at which point the formula is no longer dominated by `minVal`, but by `numVal`/`complevel` - and then slowly decrease if more validators are added as the term `numVal`/`Complevel` increases.
+
+:::note Further reading
+**[Staking rewards spec](https://github.com/vegaprotocol/specs/blob/main/protocol/0058-REWS-simple_pos_rewards.md)** - more detail on how rewards are calculated and will be in future iterations. 
+:::
+
+### Penalties
+Validator nodes that don't meet the requirements or prove to be bad actors will have rewards withheld, and a vaildator's nominators may also receive fewer (or no) rewards. 
+
+There is no token slashing, i.e., a tokenholder cannot lose their tokens through any actions of the validator.
+
+[Read more about how a validator node's performance is determined.](/docs/concepts/vega-chain#validator-node-performance)
+
+## Validator nodes
+The Vega network is operated by a number of independent validators, who each run a node. Validator nodes are responsible for agreeing on the order of transactions and creating new blocks so that all nodes can agree on the state of the network. 
+
+If a validator's stake or performance is sub-par, their validator score (and eventually performance score) will be lowered, and that validator's node will be chosen less frequently to propose a block. Vega feeds the voting power of each validator node to the Tendermint consensus algorithm. 
 
 Restricted mainnet validators will not lose stake or rewards if they have a temporary interruption of service.
+
+### Validator node performance
+A validator node's performance is measured by a validator score, and in the future, a performance score, as well. 
+
+The validator score is calculated based on how much stake a validator has, with respect to several factors. 
+
+If, at the end of an epoch, a validator does not have sufficient stake self-nominated or has overall too much stake, then their validator score will be lowered, which can impact the rewards they and their nominators receive. 
+
+Below are the two factors that can lower a validator's score, and why. 
+
+#### Not enough self-nominated stake
+Self-nominated stake refers to the amount of VEGA a validator has staked to their own node.  The minimum stake amount required is set using the network parameter `reward.staking.delegation.minimumValidatorStake`.  Not having enough self-nominated stake can have an impact on rewards. 
+
+* **Network risk**: A validator who has not committed enough stake to meet the minimum is a risk to the network because they may not be invested in keeping the network running.
+* **Validator score**: If a validator does not meet the `reward.staking.delegation.minimumValidatorStake`, then the validator's score is set to zero
+* **Reward impact**: A validator with too little self-stake forfeits their share of the rewards for each epoch they are below the threshold. However, tokenholders who nominated that validator will still receive rewards
+
+#### Too much stake
+An over-staked validator has more stake than is ideal for a healthy and functioning network. Staking to an over-staked node can affect your rewards. 
+
+* **Network risk**: The risk of an over-staked node is that it could have too much consensus voting power
+* **Validator score**: A node that is over-staked is given a lower validator score. 
+* **Reward impact**: An over-staked validator and tokenholders who nominated that validator **will not receive rewards** for every epoch the node is over-staked
+
+:::info 
+As of version 0.47.5, the Vega network does not prevent tokenholders from nominating stake that would cause a node to be over-nominated. Tokenholders must actively manage their stake and keep track of the nodes they support.
+:::
+
+#### Validator score calculations [WIP]
+
+Determining if a node is understaked or overstaked is calculated with respect to the 'optimal stake', which is how much stake a validator is expected to have, at most: 
+
+```
+Optimal stake = 
+total delegation / max of (network parameter `reward.staking.delegation.minValidators`, 
+actual number of validators / network parameter `reward.staking.delegation.competitionLevel`)
+```
+
+Validator score is calculated the following way:
+let min_validators = the value of the network parameter defining what is the minimal number of validators for vega
+let num_validator - the actual number of validators currently on vega
+let comp_level - the value of the network parameter defining competition level
+let total_stake - the sum of all stake across all validators and their delegations
+then optimal_stake is defined as total_stake / max(num_validator/comp_level, min_validators)
+the meaning of optimal_stake is how much stake we expect each validator to have at most.
+
+Now come the penalties part:
+let optimal_stake_multiplier - the value of the network parameter defining how many time the optimal stake you get penalised for if you are further than the optimal stake.
+let validator_stake_i - the stake of the ith validator
+flat_penalty = max(0, validator_stake - optimal_stake)
+higher_penalty = max(0, validator_stake - optimal_stake_multiplier * optimal_stake)
+validator_score = (validator_stake_i - flat_penalty - higher_penalty) / total_stake
+
+**Example:**
+
+Assuming the available reward pool is 1000, and there are 3 validators:
+- Validator 1 is over-staked and they are given a validator score of 0
+- Validator 2 is not over or under-staked and gets a validator score of 0.2
+- Validator 3 is also good and gets a validator score of 0.2
+
+Those scores are then normalised (divided by the sum of them):
+- Validator 1 gets a normalised score of 0
+- Validator 2 gets a normalised score of 0.5
+- Validator 3 gets a normalised score of 0.5
+
+The normalised validator score number directly affects how much each validator (and its nominators) would recieve of the 1000 reward. 
+
+- Validator 1 (and its nominators) will receive 0 rewards. Validator 2 & 3 will split the 1000 equally.
 
 ## Network life
 Vega networks will, at least initially, run for a limited time only. 

--- a/docs/concepts/vega-chain.md
+++ b/docs/concepts/vega-chain.md
@@ -17,7 +17,8 @@ Read more: [Validator nodes](/docs/concepts/vega-chain#validator-nodes)
 
 Everyone participating in keeping the network secure, robust and reliable, including nominators, is **rewarded** for keeping the network running. Not meeting the requirements of running the network can lead to penalties, such as **rewards being withheld**.
 
-Read more: [Rewards](/docs/concepts/vega-chain#rewards) 
+Read more: [Rewards](/docs/concepts/vega-chain#rewards)
+
 Read more: [Penalties](/docs/concepts/vega-chain#penalties)
 
 ### VEGA token
@@ -100,7 +101,7 @@ Validators and nominators both receive incentives for securing the network. The 
 
 **To be considered for staking rewards, a tokenholder must associate VEGA to a Vega key and nominate one or more validators.**
 
-In each epoch, rewards are distributed among validators in proportion to the number of tokens they represent (i.e., their total stake). The total stake includes a validator's own stake and the tokens nominated to that validator. Of this reward, a fixed amount is distributed among the tokenholders the validator represents. Currently that is 88.3%; though validators can vote to change that value.
+In each epoch, rewards are distributed among validators in proportion to the number of tokens they represent (i.e., their total stake). The total stake includes a validator's own stake and the tokens nominated to that validator. Of this reward, a fixed amount is distributed among the tokenholders the validator represents. Currently that is 88.3%, though validators can vote to change that value.
 
 The reward scheme uses a linear reward curve - the reward per staked token is independent of the behaviour of other tokenholders. This holds for validators as well, with the exception that there is a maximum amount of stake an individual validator can take on. 
 
@@ -128,22 +129,24 @@ Read more: [How a validator node's performance is determined](/docs/concepts/veg
 ## Validator nodes
 The Vega network is operated by a number of independent validators, who each run a node. Validator nodes are responsible for agreeing on the order of transactions and creating new blocks so that all nodes can agree on the state of the network. 
 
-If a validator's stake or performance is sub-par, their validator score (and eventually performance score) will be lowered, and that validator's node will be chosen less frequently to propose a block. Vega feeds the voting power of each validator node to the Tendermint consensus algorithm. 
+If a validator's stake or performance is sub-par, their validator score will be lowered, and that validator's node will be chosen less frequently to propose a block. (This can also affect the rewards they and their nominators receive.) Vega feeds the voting power of each validator node to the Tendermint consensus algorithm. 
 
-Restricted mainnet validators will not lose stake or rewards if they have a temporary interruption of service.
+In this version of restricted mainnet, validators will not lose stake or rewards if they have a temporary interruption of service.
 
 ### Validator node performance
-A validator node's performance is measured by a validator score, and in the future, a performance score, as well. The validator score is calculated for each epoch based on how much stake a validator has, with respect to several factors including the number of validators and the optimal stake. 
+A validator node's performance is expressed through a validator score, and in the future, a performance score as well. 
 
-If, at the end of an epoch, a validator does not have sufficient stake self-nominated or has overall too much stake, then their validator score will be lowered, which can impact the rewards they and their nominators receive. 
+The validator score is calculated for each epoch, based on how much stake a validator has as well as other factors including the total number of validators and the optimal stake. 
+
+If, at the end of an epoch, a validator does not have sufficient stake self-nominated or has overall too much stake, then their validator score will be lowered, which can impact the rewards a validator and its' nominators receive. 
 
 Below are the two factors that can lower a validator's score, and why. 
 
 #### Not enough self-nominated stake
 Self-nominated stake refers to the amount of VEGA a validator has staked to their own node.  The minimum stake amount required is set using the network parameter `reward.staking.delegation.minimumValidatorStake`. Not having enough self-nominated stake can have an impact on rewards. 
 
-* **Network risk**: A validator who has not committed enough stake to meet the minimum is a risk to the network because they may not be invested in keeping the network running.
-* **Validator score**: If a validator does not meet the `reward.staking.delegation.minimumValidatorStake`, then the validator's score is set to zero.
+* **Network risk**: A validator who has not committed enough stake to meet the minimum is a risk to the network because they may not be invested in keeping the network running
+* **Validator score**: If a validator does not meet the `reward.staking.delegation.minimumValidatorStake`, then the validator's score is set to zero
 * **Reward impact**: A validator with too little self-stake forfeits their share of the rewards for each epoch they are below the threshold. However, tokenholders who nominated that validator will still receive rewards
 
 #### Too much stake

--- a/docs/concepts/vega-chain.md
+++ b/docs/concepts/vega-chain.md
@@ -11,7 +11,7 @@ Read more: [How Vega bridges to Ethereum](/docs/concepts/vega-chain/#bridges-use
 ## Delegated proof of stake
 Vega runs on a delegated proof of stake blockchain. 
 
-Validator nodes run the Vega network, and they deciding on the validity of the blocks containing the network's transactions and thus execute those transactions. The validators who run validator nodes are required to own a minimum amount of VEGA tokens that they delegate to themselves.
+Validator nodes run the Vega network, and they decide on the validity of the blocks containing the network's transactions and thus execute those transactions. The validators who run validator nodes are required to own a minimum amount of VEGA tokens that they delegate to themselves.
 
 Read more: [Validator nodes](/docs/concepts/vega-chain#validator-nodes)
 
@@ -58,7 +58,7 @@ The Vega protocol listens for stake events from staking bridges. Currently there
 
 * When staking **locked tokens**, the Vega node interacts with the ERC20 vesting contract, which holds tokens that are locked per a vesting schedule, and provides the same utility as the staking bridge smart contract. This allows locked tokens to be used for staking and governance while not being freely tradeable. 
 
-Whether tokens are unlocked or locked, the bridge events make the Vega network of how many tokens a given party has associated and/or unassociated.
+Whether tokens are unlocked or locked, the bridge events let the Vega network know of how many tokens a given party has associated and/or unassociated.
 
 All events (including the above, plus stake per validator and others) are only registered after a certain number of block confirmations, as defined by the network parameter `blockchains.ethereumConfig`. 
 
@@ -67,7 +67,10 @@ All events (including the above, plus stake per validator and others) are only r
 :::
 
 ### Spam protection
-To avoid fragmentation or spam, there is a minimum delegateable stake that defines the smallest unit (fractions of) tokens that can be used for nomination, defined by the network parameter `validators.delegation.minAmount`. 
+There are several spam protections enabled to protect the Vega network. 
+
+- A participant who wants to submit a delegation (nomination) transaction, needs to have a balance of at least the minimum defined by the network parameter `spam.protection.delegation.min.tokens` to be able to submit the transaction
+- A participant cannot send more delegation transactions per day than the max set by the `spam.protection.max.delegations` network parameter
 
 ## Staking on Vega
 Vega networks use the ERC20 token VEGA for staking. Staking requires the combined action of associating VEGA tokens (or fractions of a token) to the Vega staking bridge contract; and using those token(s) to nominate one or more validators. 
@@ -117,7 +120,7 @@ Validators and nominators both receive incentives for securing the network. The 
 
 **To be considered for staking rewards, a tokenholder must associate VEGA to a Vega key and nominate one or more validators.**
 
-In each epoch, rewards are distributed among validators in proportion to the number of tokens they represent (i.e., their total stake). The total stake includes a validator's own stake and the tokens nominated to that validator. Of this reward, a fixed amount is distributed among the tokenholders the validator represents. Currently that is 88.3%, though validators can vote to change that value.
+In each epoch, rewards are distributed among validators in proportion to the number of tokens they represent (i.e., their total stake). The total stake includes a validator's own stake and the tokens nominated to that validator. Of this reward, a fixed amount is distributed among the tokenholders the validator represents.
 
 The reward scheme uses a linear reward curve - the reward per staked token is independent of the behaviour of other tokenholders. 
 
@@ -164,7 +167,7 @@ Below are the two factors that can lower a validator's score, and why.
 Self-nominated stake refers to the amount of VEGA a validator has staked to their own node.  The minimum stake amount required is set using the network parameter `reward.staking.delegation.minimumValidatorStake`. Not having enough self-nominated stake can have an impact on rewards. 
 
 * **Network risk**: A validator who has not committed enough stake to meet the minimum is a risk to the network because they may not be invested in keeping the network running
-* **Validator score**: If a validator does not meet the `reward.staking.delegation.minimumValidatorStake`, then the validator's score is set to zero
+* **Validator score**: If a validator does not meet the `reward.staking.delegation.minimumValidatorStake`, the validator is given a lower score, which can affect their rewards
 * **Reward impact**: A validator with too little self-stake forfeits their share of the rewards for each epoch they are below the threshold. However, tokenholders who nominated that validator will still receive rewards
 
 #### Too much stake

--- a/docs/concepts/vega-chain.md
+++ b/docs/concepts/vega-chain.md
@@ -4,14 +4,21 @@ title: Vega Chain
 hide_title: false
 ---
 
-Vega uses Tendermint as a consensus layer to form a blockchain. The rest of the information here informs on how that blockchain and its relevant components is comprised. [Read more about how Vega bridges to Ethereum](/docs/concepts/vega-chain/#bridges-used-for-staking). 
+Vega uses Tendermint as a consensus layer to form a blockchain. The rest of the information here informs on how that blockchain and its relevant components is comprised. 
+
+Read more: [How Vega bridges to Ethereum](/docs/concepts/vega-chain/#bridges-used-for-staking)
 
 ## Delegated proof of stake
-Vega runs on a delegated proof of stake blockchain. Participants -- validators and token-holders -- use their VEGA tokens to nominate the validator nodes that run the network. Non-validator participants assign the voting rights of their VEGA tokens to endorse a validator's trustworthiness. 
+Vega runs on a delegated proof of stake blockchain. Participants -- validators and token-holders -- use their VEGA tokens to nominate validator nodes that run the network. Non-validator participants assign the voting rights of their VEGA tokens to endorse a validator's trustworthiness. 
+
+Read more: [Validator nodes](/docs/concepts/vega-chain#validator-nodes)
 
 **Participants who hold a balance of VEGA, the governance asset, can stake that asset on the network.** This is done by associating those tokens to a Vega key to use as stake, and then nominating one or more validators they trust to help secure the network. 
 
-Everyone participating in keeping the network secure, robust and reliable, including nominators, is rewarded for keeping the network running. Not meeting the requirements of running the network can lead to penalties. 
+Everyone participating in keeping the network secure, robust and reliable, including nominators, is **rewarded** for keeping the network running. Not meeting the requirements of running the network can lead to penalties, such as **rewards being withheld**.
+
+Read more: [Rewards](/docs/concepts/vega-chain#rewards) 
+Read more: [Penalties](/docs/concepts/vega-chain#penalties)
 
 ### VEGA token
 Vega uses the VEGA ERC20 token for governance, which includes nominating validators to run nodes, and creating and voting on governance proposals.
@@ -21,7 +28,9 @@ A VEGA token (or fraction) can be either unassociated or associated with a Vega 
 * **Unassociated**: The tokenholder is free to do what they want with the token, but cannot nominate a validator with it
 * **Associated**: The token is locked in the staking smart contract and can be used to nominate a validator. It must be unassociated to withdraw it
 
-**All tokens can be used for staking and voting** on [governance proposals](/docs/concepts/vega-protocol#governance). This includes tokens that are locked in the vesting contract. Tokens that are staked can be used to vote, and tokens used to vote can be staked.
+**All tokens can be used for staking and voting** on governance proposals. This includes tokens that are locked in the vesting contract. Tokens that are staked can be used to vote, and tokens used to vote can be staked.
+
+Read more: [Governance of Vega](/docs/concepts/vega-protocol#governance)
 
 :::info
 A user's VEGA tokens must first be associated with a Vega key before they can be used for governance and staking.
@@ -48,15 +57,17 @@ To avoid fragmentation or spam, there is a minimum delegateable stake that defin
 ## Staking on Vega
 Vega networks use the ERC20 token VEGA for staking. Staking requires the combined action of associating VEGA tokens (or fractions of a token) to the Vega staking bridge contract; and using those token(s) to nominate one or more validators. 
 
-**Epochs**
+#### Epochs
 An epoch is a time period during which staking changes can be announced and then implemented. Changes that are announced in one epoch will only be executed in the following epoch (excepting 'un-nominate now' - see below). The length of an epoch is set by the network parameter `validators.epoch.length`. 
 
 ### Nominating validators
 Using tokens to nominate validators keeps the decentralised network functioning. 
 
-Tokenholders can nominate validators to encourage a diverse set of reliable nodes running the network, and to give the community the opportunity to disincentivise and/or remove bad validators. Tokenholders who nominate validators are also eligible for rewards. [**Read more about rewards for staking.**](/docs/concepts/vega-chain#rewards)
+Tokenholders can nominate validators to encourage a diverse set of reliable nodes running the network, and to give the community the opportunity to disincentivise and/or remove bad validators. Tokenholders who nominate validators are also eligible for rewards. 
 
-When a tokenholder chooses a validator (or validators) to nominate with their tokens, the amount is immediately subtracted from their available balance, and is used at the start of the next epoch to actively nominate those validator(s). 
+When a tokenholder chooses a validator (or validators) to nominate with their tokens, the amount is immediately subtracted from their available balance, and is used at the start of the next epoch to actively nominate those validator(s).
+
+Read more: [Rewards for staking](/docs/concepts/vega-chain#rewards)
 
 :::info
 VEGA tokenholders can use **[token.vega.xyz](https://token.vega.xyz)** to associate their tokens and nominate validators. A Vega Wallet and Ethereum wallet are both required. CoinList custodial users should confirm with CoinList how staking works for them.
@@ -72,14 +83,12 @@ Exceptions to automatic nomination:
 ### Un-nominating validators
 Participants can remove their nomination at the end of an epoch, or immediately. The un-nominated tokens will be restored back to the participant's associated token balance.
 
-**Un-nominate towards the end of the epoch**
-
+#### Un-nominate towards the end of the epoch
 A participant can un-nominate towards the end of the current epoch, which means the stake is not used for the validator from the following epoch. 
 
 The action is announced in the next available block of the same epoch, but the nominator keeps their nomination active until the last block of that epoch. At that point, the tokens are returned. The nominator cannot move those tokens before the epoch ends.
 
-**Un-nominate now**
-
+#### Un-nominate now
 A participant can choose to un-nominate at any time, and the action is executed immediately following the block it is announced in (within the same epoch). 
 
 The participant will not receive any rewards from the validator in that epoch. The tokens are marked as available to the participant.
@@ -87,43 +96,23 @@ The participant will not receive any rewards from the validator in that epoch. T
 ## Staking rewards & penalties
 
 ### Rewards
-Validators and nominators both receive incentives from the network, depending on factors including how much stake is nominated. 
+Validators and nominators both receive incentives for securing the network. The amount of those incentives, rewarded as VEGA, depends on factors including how much stake is nominated. 
 
 **To be considered for staking rewards, a tokenholder must associate VEGA to a Vega key and nominate one or more validators.**
 
-In each epoch, rewards are distributed among validators in proportion to the number of tokens they represent (i.e., their total stake)*. The total stake includes a validator's own stake and the tokens nominated to that validator. Of this reward, a fixed amount is distributed among the tokenholders the validator represents. Currently that value is 88.3%; though validators can vote to change that value.
+In each epoch, rewards are distributed among validators in proportion to the number of tokens they represent (i.e., their total stake). The total stake includes a validator's own stake and the tokens nominated to that validator. Of this reward, a fixed amount is distributed among the tokenholders the validator represents. Currently that is 88.3%; though validators can vote to change that value.
 
-*This is to a maximum number, after which their proportion no longer increases. 
-
-The reward scheme uses a linear reward curve - the reward per staked token is independent of the behaviour of other tokenholders.  This holds for validators as well, with the exception of the a maximum amount of stake an individual validator can take on. [Read more about the risks of over-staked validators.](/docs/concepts/vega-chain#too-much-stake)
+The reward scheme uses a linear reward curve - the reward per staked token is independent of the behaviour of other tokenholders. This holds for validators as well, with the exception that there is a maximum amount of stake an individual validator can take on. 
 
 At the end of each epoch, reward payments are calculated per active validator, and then some of that reward is divided between their nominators. 
+
+Read more: [Risks of over-staked validators](/docs/concepts/vega-chain#too-much-stake)
  
 :::info
-VEGA tokenholders can use **[token.vega.xyz](https://token.vega.xyz)** to associate their tokens and nominate validators to receive rewards. CoinList
-custodial users should confirm with CoinList how staking works for them.
+VEGA tokenholders can use **[token.vega.xyz](https://token.vega.xyz)** to associate their tokens and nominate validators to receive rewards. Staking rewards are paid into  your Vega wallet after each epoch ends. 
+
+CoinList custodial users should confirm with CoinList how staking works for them.
 :::
-
-#### Reward calculations [WIP]
-
-== The proportion that goes to nominators is defined by the network parameter `reward.staking.delegation.delegatorShare`. 
-
-Two parameters are relevant to the calculation of staking rewards, as well as two network properties.
-
-`MinVal` is the minimum tolerable number of validators. If the number of validators goes below this value, the maximum size of a validator will shrink to the point that tokenholders are motivated to bring in more validators.
-
-`CompetitionLevel` defines how large validators can get relative to each other. The current value (3.1) means that for all validators to reach their optimal revenue, a total of 310% of staked tokens would be required, leaving motivation for most validators to obtain more stake.
-
-The other two parameters are the total amount of staked tokens, as well as the number of validators (currently 13).
-
-```
-func calcValidatorScore(normalisedValStake, minVal, compLevel, numVal float64) float64 {
-a := math.Max(minVal, numVal/compLevel)
-return math.Min(normalisedValStake, 1/a)
-}
-```
-
-With the current parameters, the maximum delegation a validator can represent is 20% of the total number of delegated tokens, and this value will stay the same up to 15 validators - at which point the formula is no longer dominated by `minVal`, but by `numVal`/`complevel` - and then slowly decrease if more validators are added as the term `numVal`/`Complevel` increases.
 
 :::note Further reading
 **[Staking rewards spec](https://github.com/vegaprotocol/specs/blob/main/protocol/0058-REWS-simple_pos_rewards.md)** - more detail on how rewards are calculated and will be in future iterations. 
@@ -132,9 +121,9 @@ With the current parameters, the maximum delegation a validator can represent is
 ### Penalties
 Validator nodes that don't meet the requirements or prove to be bad actors will have rewards withheld, and a vaildator's nominators may also receive fewer (or no) rewards. 
 
-There is no token slashing, i.e., a tokenholder cannot lose their tokens through any actions of the validator.
+There is no token slashing, i.e., a tokenholder cannot lose their tokens through any actions of as validator.
 
-[Read more about how a validator node's performance is determined.](/docs/concepts/vega-chain#validator-node-performance)
+Read more: [How a validator node's performance is determined](/docs/concepts/vega-chain#validator-node-performance)
 
 ## Validator nodes
 The Vega network is operated by a number of independent validators, who each run a node. Validator nodes are responsible for agreeing on the order of transactions and creating new blocks so that all nodes can agree on the state of the network. 
@@ -144,63 +133,56 @@ If a validator's stake or performance is sub-par, their validator score (and eve
 Restricted mainnet validators will not lose stake or rewards if they have a temporary interruption of service.
 
 ### Validator node performance
-A validator node's performance is measured by a validator score, and in the future, a performance score, as well. 
-
-The validator score is calculated based on how much stake a validator has, with respect to several factors. 
+A validator node's performance is measured by a validator score, and in the future, a performance score, as well. The validator score is calculated for each epoch based on how much stake a validator has, with respect to several factors including the number of validators and the optimal stake. 
 
 If, at the end of an epoch, a validator does not have sufficient stake self-nominated or has overall too much stake, then their validator score will be lowered, which can impact the rewards they and their nominators receive. 
 
 Below are the two factors that can lower a validator's score, and why. 
 
 #### Not enough self-nominated stake
-Self-nominated stake refers to the amount of VEGA a validator has staked to their own node.  The minimum stake amount required is set using the network parameter `reward.staking.delegation.minimumValidatorStake`.  Not having enough self-nominated stake can have an impact on rewards. 
+Self-nominated stake refers to the amount of VEGA a validator has staked to their own node.  The minimum stake amount required is set using the network parameter `reward.staking.delegation.minimumValidatorStake`. Not having enough self-nominated stake can have an impact on rewards. 
 
 * **Network risk**: A validator who has not committed enough stake to meet the minimum is a risk to the network because they may not be invested in keeping the network running.
-* **Validator score**: If a validator does not meet the `reward.staking.delegation.minimumValidatorStake`, then the validator's score is set to zero
+* **Validator score**: If a validator does not meet the `reward.staking.delegation.minimumValidatorStake`, then the validator's score is set to zero.
 * **Reward impact**: A validator with too little self-stake forfeits their share of the rewards for each epoch they are below the threshold. However, tokenholders who nominated that validator will still receive rewards
 
 #### Too much stake
 An over-staked validator has more stake than is ideal for a healthy and functioning network. Staking to an over-staked node can affect your rewards. 
 
 * **Network risk**: The risk of an over-staked node is that it could have too much consensus voting power
-* **Validator score**: A node that is over-staked is given a lower validator score. 
-* **Reward impact**: An over-staked validator and tokenholders who nominated that validator **will not receive rewards** for every epoch the node is over-staked
+* **Validator score**: A node that is over-staked is given a lower validator score - the more over-staked it is, the lower the score 
+* **Reward impact**: If a validator is too far from optimal stake, the validator and tokenholders who nominated that validator **will not receive rewards** for every epoch the node is heavily over-staked
 
 :::info 
 As of version 0.47.5, the Vega network does not prevent tokenholders from nominating stake that would cause a node to be over-nominated. Tokenholders must actively manage their stake and keep track of the nodes they support.
 :::
 
-#### Validator score calculations [WIP]
+#### Validator score calculations
+The validator score takes into account a number of factors, including the total stake, optimal stake, minimum number of validators required, actual number of validators, and more. See below for how the validator score is calculated. 
 
-Determining if a node is understaked or overstaked is calculated with respect to the 'optimal stake', which is how much stake a validator is expected to have, at most: 
+Factors that affect the validator score:
 
-```
-Optimal stake = 
-total delegation / max of (network parameter `reward.staking.delegation.minValidators`, 
-actual number of validators / network parameter `reward.staking.delegation.competitionLevel`)
-```
+`min_validators` = value of the network parameter that defines the minimum viable number of validators to run Vega:
+`num_validators` = actual number of validators running nodes on Vega
+`comp_level` = value of the network parameter that defines the competition level
+`total_stake` = sum of all stake across all validators and their delegations
+`optimal_stake` = total delegation divided by the greater of `min_validators`, OR (`num_validators` / `comp_level`): Optimal stake is how much stake each validator is expected to have, at most
+`optimal_stake_multiplier` = value defined by the network parameter, which indicates how many times the optimal stake a validator is penalised for, if they are further than the optimal stake
 
-Validator score is calculated the following way:
-let min_validators = the value of the network parameter defining what is the minimal number of validators for vega
-let num_validator - the actual number of validators currently on vega
-let comp_level - the value of the network parameter defining competition level
-let total_stake - the sum of all stake across all validators and their delegations
-then optimal_stake is defined as total_stake / max(num_validator/comp_level, min_validators)
-the meaning of optimal_stake is how much stake we expect each validator to have at most.
+`validator_stake_i` = stake of the given validator whose score is being calculated
+`flat_penalty` = the greater of 0, OR (`validator_stake` - `optimal_stake`)
+`higher_penalty` = the greater of 0, OR (`validator_stake` - `optimal_stake_multiplier` * `optimal_stake`)
 
-Now come the penalties part:
-let optimal_stake_multiplier - the value of the network parameter defining how many time the optimal stake you get penalised for if you are further than the optimal stake.
-let validator_stake_i - the stake of the ith validator
-flat_penalty = max(0, validator_stake - optimal_stake)
-higher_penalty = max(0, validator_stake - optimal_stake_multiplier * optimal_stake)
-validator_score = (validator_stake_i - flat_penalty - higher_penalty) / total_stake
+The validator score is calculated as follows:
+
+`validator_score` = (`validator_stake_i` - `flat_penalty` - `higher_penalty`) / `total_stake`
 
 **Example:**
 
 Assuming the available reward pool is 1000, and there are 3 validators:
-- Validator 1 is over-staked and they are given a validator score of 0
+- Validator 1 is heavily over-staked and they are given a validator score of 0
 - Validator 2 is not over or under-staked and gets a validator score of 0.2
-- Validator 3 is also good and gets a validator score of 0.2
+- Validator 3 is also well-staked and gets a validator score of 0.2
 
 Those scores are then normalised (divided by the sum of them):
 - Validator 1 gets a normalised score of 0

--- a/docs/concepts/vega-chain.md
+++ b/docs/concepts/vega-chain.md
@@ -101,7 +101,7 @@ Exceptions to automatic nomination:
 ### Un-nominating validators
 Participants can remove their nomination at the end of an epoch, or immediately. The un-nominated tokens will be restored back to the participant's associated token balance. 
 
-If nominated tokens are moved to a different Ethereum address, they are un-nominated immediately, (equivalent to ['un-nominate now'](/docs/concepts/vega-chain#un-nominate-now)) and rewards are forfeited for that epoch. 
+If nominated tokens are moved to a different Ethereum address, they are un-nominated immediately, (equivalent to ['un-nominate now'](/docs/concepts/vega-chain#un-nominate-now)) and rewards are forfeited for that epoch. In this case, or any in which you dissociate tokens without first removing the nomination from a particular validator, the tokens are un-nominated from each validator you've nominated in proportion to the nomination. 
 
 #### Un-nominate towards the end of the epoch
 A participant can un-nominate towards the end of the current epoch, which means the stake is not used for the validator from the following epoch. The participant, and their nominated validator, is entitled to the rewards from that epoch (unlike when un-nominating now). 

--- a/docs/concepts/vega-chain.md
+++ b/docs/concepts/vega-chain.md
@@ -7,16 +7,19 @@ hide_title: false
 Vega uses Tendermint as a consensus layer to form a blockchain. The rest of the information here informs on how that blockchain and its relevant components is comprised. [Read more about how Vega bridges to Ethereum](/docs/concepts/vega-chain/#bridges-used-for-staking). 
 
 ## Delegated proof of stake
-Vega runs on a delegated proof of stake blockchain. Participants--validators and token-holders--use their VEGA tokens to nominate the validator nodes that run the network. Non-validator participants assign the voting rights of their VEGA tokens to endorse a validator's trustworthiness. 
+Vega runs on a delegated proof of stake blockchain. Participants -- validators and token-holders -- use their VEGA tokens to nominate the validator nodes that run the network. Non-validator participants assign the voting rights of their VEGA tokens to endorse a validator's trustworthiness. 
 
 **Participants who hold a balance of VEGA, the governance asset, can stake that asset on the network.** This is done by associating those tokens to a Vega key to use as stake, and then nominating one or more validators they trust to help secure the network. 
 
-Everyone participating in staking is rewarded for keeping the network running (and in the future can be penalised for not meeting the requirements of running the network). 
+Everyone participating in keeping the network secure, robust and reliable, including nominators, is rewarded for keeping the network running. Not meeting the requirements of running the network can lead to penalties. 
 
-<!-- Penalties: 
-- Validators can lose their VEGA to the network if they don't meet the requirements or prove to be bad actors. The tokens are sent to the insurance pool. (link to insurance pool section when available) 
-- Nominators will lose future rewards
+### Penalties 
+Validators that don't meet the requirements or prove to be bad actors will have rewards withheld. Nominators of a validator that doesn't meet the requirements will also receive fewer (or no) rewards. A validator's performance is calculated based on their **validator score**, and in the future their **performance score**. 
 
+### Validator score
+The validator score is calculated based on how much stake a validator has. If, at the end of an epoch, a validator does not have sufficient self-stake or has overall too much stake, then their validator score will be lowered. 
+
+<!--
 ### ***Further reading***
 Link to spec for staking and validator rewards when publicly available. (valpol)
 -->
@@ -54,8 +57,6 @@ VEGA tokenholders can use [token.vega.xyz](https://token.vega.xyz) to associate 
 
 ### Maximum stake per validator
 Each validator has a maximum amount of stake that they can accept. During restricted mainnet, this will be the same amount for all validators. 
-
-When a validator's token limit is reached, and more nomination would cause a validator's maximum stake to be exceeded, any additional nominated tokens will not be used. The remaining amount will be available to use to nominate another validator after the next epoch has begun.
 
 The max stake per validator equation includes all nominations and un-nominations requested in the next epoch, and the current epoch's active nominations, divided by the optimal number of validators. The optimal number of validators is defined using network parameters. 
 

--- a/docs/concepts/vega-chain.md
+++ b/docs/concepts/vega-chain.md
@@ -15,15 +15,15 @@ Validator nodes run the Vega network, and they decide on the validity of the blo
 
 Read more: [Validator nodes](/docs/concepts/vega-chain#validator-nodes)
 
-**Participants who hold a balance of VEGA, the governance asset, can use their tokens to nominate validator nodes.** This is done by associating those tokens to a Vega key to use as stake, and then nominating one or more validators they trust to help secure the network. Nominate validators loans the consensus voting weight of the VEGA tokens to endorse a validator's trustworthiness. 
+**Participants who hold a balance of VEGA, the governance asset, can use their tokens to nominate validator nodes.** This is done by associating those tokens to a Vega key to use as stake, and then nominating one or more validators they trust to help secure the network. Nominating validators loans the consensus voting weight of the VEGA tokens to endorse a validator's trustworthiness. 
 
-Tokens, in addition to their use for nominating validators, also grant tokenholder voting rights on governance actions. If a token is delegated, its governance voting rights stay with the tokenholder and are not transferred to any validators the tokenholder nominates.
+Tokens, in addition to their use for nominating validators, also grant tokenholder voting rights on governance actions. If a token is delegated, its governance voting rights stay with the tokenholder and are not transferred to any validators that the tokenholder nominates.
 
 Everyone participating in keeping the network secure, robust and reliable, including nominators, is **rewarded** for keeping the network running. Not meeting the requirements of running the network can lead to penalties, such as **rewards being withheld**.
 
 Read more: [Rewards](/docs/concepts/vega-chain#rewards)
 
-Vega is non-slashing -- there is no mechanism through which a tokenholder can lose a staked token through a validator being punished. Any measures to that end use different mechanisms that will affect a bad validator's (and potentially their delegators') revenue, but not the delegated tokens themselves.
+Vega is non-slashing -- there is no mechanism through which a tokenholder can lose a staked token through a validator being punished. Any measures to that end use different mechanisms that will affect a bad validator's (and potentially their delegators') revenue, but does not affect the delegated tokens themselves.
 
 Read more: [Penalties](/docs/concepts/vega-chain#penalties)
 
@@ -44,12 +44,12 @@ A user's VEGA tokens must first be associated with a Vega key before they can be
 :::
 
 ### Bridges used for staking
-Associating and dissociating VEGA tokens to a Vega key are initiated on Ethereum, rather than on the Vega protocol. This allows VEGA to be staked with a Vega public key without any action on the Vega network, and without putting the tokens under the control of the Vega network.
+Both associating and dissociating VEGA tokens to a Vega key are initiated on Ethereum, rather than on the Vega protocol. This allows VEGA to be staked with a Vega public key without any action on the Vega network, and without putting the tokens under the control of the Vega network.
 
 All governance voting and validator nominations happen exclusively on the Vega chain. 
 
 :::info
-Ethereum gas fees are only incurred in the process of associating tokens to a Vega key and transferring rewards from a Vega key to an Ethereum address.
+Ethereum gas fees are only incurred in the process of associating tokens to a Vega key and transferring rewards from a Vega key to an Ethereum address. Nominating validators and changing nominations does not incur gas fees.
 :::
 
 The Vega protocol listens for stake events from staking bridges. Currently there are two bridges: one for staking unlocked, freely tradeable tokens, and one that connects to the vesting contract for locked, untradeable tokens. 
@@ -58,7 +58,7 @@ The Vega protocol listens for stake events from staking bridges. Currently there
 
 * When staking **locked tokens**, the Vega node interacts with the ERC20 vesting contract, which holds tokens that are locked per a vesting schedule, and provides the same utility as the staking bridge smart contract. This allows locked tokens to be used for staking and governance while not being freely tradeable. 
 
-Whether tokens are unlocked or locked, the bridge events let the Vega network know of how many tokens a given party has associated and/or unassociated.
+Whether tokens are unlocked or locked, the bridge events let the Vega network know how many tokens a given party has associated and/or dissociated.
 
 All events (including the above, plus stake per validator and others) are only registered after a certain number of block confirmations, as defined by the network parameter `blockchains.ethereumConfig`. 
 
@@ -69,8 +69,8 @@ All events (including the above, plus stake per validator and others) are only r
 ### Spam protection
 There are several spam protections enabled to protect the Vega network. 
 
-- A participant who wants to submit a delegation (nomination) transaction, needs to have a balance of at least the minimum defined by the network parameter `spam.protection.delegation.min.tokens` to be able to submit the transaction
-- A participant cannot send more delegation transactions per day than the max set by the `spam.protection.max.delegations` network parameter
+* A participant who wants to submit a delegation (nomination) transaction, needs to have a balance of at least the minimum defined by the network parameter `spam.protection.delegation.min.tokens` to be able to submit the transaction
+* A participant cannot send more delegation transactions per day than the max set by the `spam.protection.max.delegations` network parameter
 
 ## Staking on Vega
 Vega networks use the ERC20 token VEGA for staking. Staking requires the combined action of associating VEGA tokens (or fractions of a token) to the Vega staking bridge contract; and using those token(s) to nominate one or more validators. 
@@ -101,7 +101,7 @@ Exceptions to automatic nomination:
 ### Un-nominating validators
 Participants can remove their nomination at the end of an epoch, or immediately. The un-nominated tokens will be restored back to the participant's associated token balance. 
 
-If nominated tokens are moved to a different Ethereum address, they are un-nominated immediately, (equivalent to ['un-nominate now'](/docs/concepts/vega-chain#un-nominate-now)) and rewards are forfeited for that epoch. In this case, or any in which you dissociate tokens without first removing the nomination from a particular validator, the tokens are un-nominated from each validator you've nominated in proportion to the nomination. 
+If nominated tokens are moved to a different Ethereum address, they are un-nominated immediately, (equivalent to ['un-nominate now'](/docs/concepts/vega-chain#un-nominate-now)) and rewards are forfeited for that epoch. In this case, or any case in which you dissociate tokens without first removing the nomination from a particular validator, the tokens are un-nominated from each validator you've nominated, in proportion to the nomination. 
 
 #### Un-nominate towards the end of the epoch
 A participant can un-nominate towards the end of the current epoch, which means the stake is not used for the validator from the following epoch. The participant, and their nominated validator, is entitled to the rewards from that epoch (unlike when un-nominating now). 
@@ -143,7 +143,7 @@ CoinList custodial users should confirm with CoinList how staking works for them
 ### Penalties
 Validator nodes that don't meet the requirements or prove to be bad actors will have rewards withheld, and a vaildator's nominators may also receive fewer (or no) rewards. 
 
-There is no token slashing, i.e., a tokenholder cannot lose their tokens through any actions of as validator.
+There is no token slashing, i.e., a tokenholder cannot lose their tokens through any actions of a validator.
 
 Read more: [How a validator node's performance is determined](/docs/concepts/vega-chain#validator-node-performance)
 
@@ -159,12 +159,12 @@ A validator node's performance is expressed through a validator score, and in th
 
 The validator score is calculated for each epoch, based on how much stake a validator has as well as other factors including the total number of validators and the optimal stake. 
 
-If, at the end of an epoch, a validator does not have sufficient stake self-nominated or has overall too much stake, then their validator score will be lowered, which can impact the rewards a validator and its' nominators receive. 
+If, at the end of an epoch, a validator does not have sufficient stake self-nominated or has overall too much stake, then their validator score will be lowered, which can impact the rewards a validator and its nominators receive. 
 
 Below are the two factors that can lower a validator's score, and why. 
 
 #### Not enough self-nominated stake
-Self-nominated stake refers to the amount of VEGA a validator has staked to their own node.  The minimum stake amount required is set using the network parameter `reward.staking.delegation.minimumValidatorStake`. Not having enough self-nominated stake can have an impact on rewards. 
+Self-nominated stake refers to the amount of VEGA a validator has staked to their own node.  The minimum stake amount required is defined by the network parameter `reward.staking.delegation.minimumValidatorStake`. Not having enough self-nominated stake can have an impact on rewards. 
 
 * **Network risk**: A validator who has not committed enough stake to meet the minimum is a risk to the network because they may not be invested in keeping the network running
 * **Validator score**: If a validator does not meet the `reward.staking.delegation.minimumValidatorStake`, the validator is given a lower score, which can affect their rewards
@@ -186,7 +186,7 @@ The validator score takes into account a number of factors, including the total 
 
 Factors that affect the validator score:
 
-`min_validators` = value of the network parameter that defines the minimum viable number of validators to run Vega:
+`min_validators` = value of the network parameter that defines the minimum viable number of validators to run Vega
 `num_validators` = actual number of validators running nodes on Vega
 `comp_level` = value of the network parameter that defines the competition level
 `total_stake` = sum of all stake across all validators and their delegations


### PR DESCRIPTION
This PR covers the concept of validator scores, in the context of why rewards might not be distributed based on validators not being appropriately staked. 

The info should be correct for version 0.47.5. 