### PR TITLE
Expand desktop wallet guidance

### DIFF
--- a/docs/tools/vega-wallet/cli-wallet/latest/create-wallet.md
+++ b/docs/tools/vega-wallet/cli-wallet/latest/create-wallet.md
@@ -36,9 +36,9 @@ In your command line interface, you can view a list of available commands by run
 
 Download `vegawallet-windows-amd64.zip`
 
-You may need to change your system preferences for this specific instance, in order to run Vega Wallet. If you open the file from downloads, you may get a message from Windows Defender saying "`vegawallet-windows-amd64` cannot be opened because it is from an unidentified developer".
+You may need to change your system preferences for this specific instance, in order to run Vega Wallet. If you open the file from downloads, you may get a message from Windows Defender saying it prevented an unrecognised app from starting.
 
-Click on the (More info) text, which will reveal a button to "Run anyway".
+Click on the (More info) text, which will reveal the option to "Run anyway".
 </TabItem>
 <TabItem value="mac" label="MacOS">
 

--- a/docs/tools/vega-wallet/desktop-app/index.md
+++ b/docs/tools/vega-wallet/desktop-app/index.md
@@ -3,6 +3,6 @@ title: Desktop Wallet
 hide_title: false
 ---
 
-The Vega Wallet is available to use as a desktop application. It allows you to create and restore wallets, connect to Vega networks and start Vega dApps through a visual interface.
+The Vega Wallet is available to use as a desktop application. It allows you to use your existing Vega wallet, create new wallets, or restore wallets. The desktop app also lets you connect to Vega networks and start Vega dApps through the visual interface.
 
-**[Get started](/docs/tools/vega-wallet/desktop-app/latest/getting-started)**: Start by downloading the software, and then create a new wallet or restore an existing Vega wallet. 
+**[Get started](/docs/tools/vega-wallet/desktop-app/latest/getting-started)**: Start by downloading the software, and then use an existing Vega wallet, create a new wallet or restore a wallet.

--- a/docs/tools/vega-wallet/desktop-app/latest/getting-started.md
+++ b/docs/tools/vega-wallet/desktop-app/latest/getting-started.md
@@ -5,7 +5,9 @@ hide_title: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The Vega Wallet is available to use as a desktop app. Set-up takes less than 5 minutes, from downloading the software to connecting to a Vega dApp.
+You can now connect to an existing Vega wallet, or create a new wallet, using the Vega Wallet desktop app.
+
+Set-up takes less than 5 minutes, from downloading the software to connecting to a Vega dApp.
 
 ## Download and start the Vega Wallet desktop app
 
@@ -28,6 +30,8 @@ Download `vegawallet-desktop-windows-amd64.zip`
 **For Windows devices with an ARM processor** ([See Windows FAQ](https://support.microsoft.com/en-us/windows/windows-arm-based-pcs-faq-477f51df-2e3b-f68f-31b0-06f5e4f8ebb5#ID0EFD=Windows_11)):
 
 Download `vegawallet-desktop-windows-arm64.zip`
+
+You may need to change your system preferences for this specific instance, in order to run Vega Wallet. If you open the file from downloads, you may get a message from Windows Defender saying it prevented an unrecognised app from starting.
 
 </TabItem>
 <TabItem value="mac" label="MacOS">
@@ -54,6 +58,11 @@ Click on the compressed folder to get access to the app.
 #### 3. Start the app 
 Double-click on the Vega Wallet desktop app icon to start the desktop app. 
 
+## Use existing wallet 
+If you previously created a Vega wallet, such as using the CLI app, the first time you use the Vega Wallet desktop app you can choose to use an existing wallet. 
+
+If you are updating to a new version of the Vega Wallet desktop app, the app will load your existing Vega wallet (or wallets) on the wallet screen.
+
 ## Generate new wallet
 If you don't already have a Vega wallet, create a new wallet. 
 
@@ -63,23 +72,33 @@ If you don't already have a Vega wallet, create a new wallet.
 4. Your first keypair will be created for you. You can create more keys for that wallet but you only need one to start interacting with Vega. 
 5. Choose a Vega network to connect to: Click on the arrow in the bottom bar of the app. 
 
-## Restore existing wallet
-If you already have a Vega wallet with keys, recover the wallet using your recovery phrase. 
+## Restore wallet
+If your Vega wallet was created on a different device, or you lost access to it but have the recovery phrase, you can recover the wallet using that recovery phrase. 
 
 1. Open the app. 
 2. Click on "Use recovery phrase"
 3. Enter your recovery phrase, exactly in the order that it was first presented to you. 
-4. Choose your wallet version (1 or 2). 
+4. Identify if your wallet was version 1 or 2 by choosing the version number. 
 5. Choose a Vega network to connect to: Click on the arrow in the bottom bar of the app. 
 
 ## Troubleshooting
 The Vega Wallet desktop app does not yet have the full functionality of the CLI wallet app.
 
 ### Not yet supported
-To do any of the following, you will need to use the **[CLI wallet](/docs/tools/vega-wallet/cli-wallet)**:
+To do any of the following, you will need to use the **[CLI wallet](/docs/tools/vega-wallet/cli-wallet)** app:
 * Customise key details
 * Isolate keys
 * Build and send commands 
+
+### 'Wallet already exists' error when recovering wallet
+
+#### Problem
+You recover a wallet using your recovery phrase. When you enter the wallet name, you get an error of `Wallet with this name already exists`. 
+
+#### Solution
+The wallet you are trying to recover already exists on your device. You can use your existing wallet with the Vega Wallet desktop app. On the onboarding screen, choose `Use existing` to connect to an existing Vega wallet. 
+
+If you see the error message `Wallet with this name already exists` but you do not see that wallet on the Wallets screen, then report the issue on **[Nolt](https://vega-testnet.nolt.io/)**. 
 
 ### Wallet recovery provides wrong keys 
 #### Problem

--- a/docs/tools/vega-wallet/index.md
+++ b/docs/tools/vega-wallet/index.md
@@ -3,11 +3,11 @@ title: Vega Wallet
 hide_title: false
 ---
 
-Vega Wallet allows you to manage wallets and key pairs, and sign transactions. 
+Vega Wallet allows you to manage wallets and key pairs, and sign transactions. You can interact with a Vega wallet and its keys through two different apps: 
 
 ## Vega Wallet Desktop app
 The **[desktop wallet](/docs/tools/vega-wallet/desktop-app/)** provides a visual interface to: 
-* Connect to existing wallet
+* Connect to existing Vega wallet
 * Create new wallet 
 * Connect to networks
 * Sign transactions


### PR DESCRIPTION
- Add guidance about Windows Defender. (Even though the software is signed, it still pops up a warning)
- Add info about how to use existing wallet, which is different from restoring wallet