### PR TITLE
fixed link on homepage

### DIFF
--- a/src/components/HomepageFeatures.js
+++ b/src/components/HomepageFeatures.js
@@ -12,7 +12,7 @@ const FeatureList = [
       <>
         Restricted mainnet is a decentralised network run by a set of
         validators. Read about the underlying framework under{" "}
-        <a href={`./docs/${latestVersion}/concepts`}>concepts</a>.
+        <a href={`./docs/${latestVersion}/concepts/new-to-vega`}>concepts</a>.
       </>
     ),
   },


### PR DESCRIPTION
This link was broken, this PR fixes it
<img width="1388" alt="Screenshot 2022-05-18 at 14 32 39" src="https://user-images.githubusercontent.com/13255539/169051038-bc8d5f2d-aa11-4c7c-9e6b-129792880777.png">
