### PR TITLE
Fix broken links on tools/vega-wallet page

### DIFF
--- a/versioned_docs/version-v0.47.0/tools/vega-wallet/index.md
+++ b/versioned_docs/version-v0.47.0/tools/vega-wallet/index.md
@@ -8,7 +8,7 @@ Vega Wallet allows you to manage wallets and key pairs, and sign transactions.
 You can interact with a Vega wallet and its keys through two different apps:
 
 ## Vega Wallet desktop app
-The **[desktop wallet](./desktop-app/)** provides a visual interface to: 
+The **[desktop wallet](./vega-wallet/desktop-app/)** provides a visual interface to: 
 * Connect to existing Vega wallet
 * Create new wallet 
 * Connect to networks
@@ -16,10 +16,10 @@ The **[desktop wallet](./desktop-app/)** provides a visual interface to:
 * Run and connect to Vega apps, such as the token dApp
 
 ## Vega Wallet CLI app
-Use the **[command line app](./cli-wallet/)** to do everything you can do with the desktop app, plus:
+Use the **[command line app](./vega-wallet/cli-wallet/)** to do everything you can do with the desktop app, plus:
 * Customise key details 
 * Isolate keys
 * Build and send commands
 
 ## What is a wallet?
-**[Wallet concepts](../../concepts/vega-wallet)**: Read about how the Vega Wallet works and what the terms like 'wallet name' and 'recovery phrase' mean.
+**[Wallet concepts](../concepts/vega-wallet)**: Read about how the Vega Wallet works and what the terms like 'wallet name' and 'recovery phrase' mean.


### PR DESCRIPTION
Links on https://docs.vega.xyz/docs/mainnet/tools/vega-wallet are broken. I get there from https://token.vega.xyz/staking