### PR TITLE
Make README more approachable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ You can make changes through the GitHub web UI, or if you have a more complex se
 Anyone is welcome to create a Pull Request. If you're looking to help out, check out the [Issues list](https://github.com/vegaprotocol/documentation/issues) and ensure there isn't an existing [Pull Request](https://github.com/vegaprotocol/documentation/pulls) for the issue.
 
 ## Current process
-1. All changes should be made in a branch, and proposed via a pull request.
+1. All changes must be be made in a branch, and proposed via a pull request.
 2. The reviewer will check the changes, check the deploy preview and approve or request changes
 3. Finally changes are merged
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Anyone is welcome to create a Pull Request. If you're looking to help out, check
 ## Current process
 1. All changes must be be made in a branch, and proposed via a pull request.
 2. The reviewer will check the changes, check the deploy preview and approve or request changes
-3. Finally changes are merged
+3. Once the review is approved, changes can be merged
 
 ## Editing on GitHub
 You can fork the repository and edit your own copy, or propose changes via the GitHub UI. When you are finished and create a Pull Request, a Netlify Deploy Preview will be built and linked. This can be used to review your changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Making changes
+You can make changes through the GitHub web UI, or if you have a more complex set of changes you can clone the repository, make your changes locally and create a pull request. Whenever a pull request is submitted, a deploy preview will be built to demonstrate your changes.
+
+Anyone is welcome to create a Pull Request. If you're looking to help out, check out the [Issues list](https://github.com/vegaprotocol/documentation/issues) and ensure there isn't an existing [Pull Request](https://github.com/vegaprotocol/documentation/pulls) for the issue.
+
+## Current process
+1. All changes should be made in a branch, and proposed via a pull request.
+2. The reviewer will check the changes, check the deploy preview and approve or request changes
+3. Finally changes are merged
+
+## Editing on GitHub
+You can fork the repository and edit your own copy, or propose changes via the GitHub UI. When you are finished and create a Pull Request, a Netlify Deploy Preview will be built and linked. This can be used to review your changes.
+
+## Local development
+The [Docusaurus installation guide](https://docusaurus.io/docs/installation) covers the  software requirements for Docusaurus itself. The following guide walks you through getting the Vega documentation served locally.
+
+### Requirements
+
+The best way to get the correct version of node is using the `nvm` utility which can be installed from these instructions:
+
+`https://github.com/nvm-sh/nvm#installing-and-updating`
+
+Once nvm is installed (check with `nvm --version`) you can run the following command from inside the root of the documentation folder to download and install the correct version of node required by the script:
+
+```
+> nvm install
+> npm --version
+```
+
+`Yarn` can be install by running:
+
+```
+> npm install -g yarn
+> yarn --version
+```
+
+The libraries needed by yarn can be installed by:
+
+```
+> yarn install
+```
+
+If you are regenerating the API documentation, you need to have Python3 installed. You can check if you have by running:
+
+```
+> python3 --version
+```
+
+
+### Clone, setup and run the server
+```bash
+git clone git@github.com:vegaprotocol/documentation.git
+cd documentation
+nvm install
+yarn install
+yarn run serve
+```
+
+### Regenerating the API documentation
+Edit `scripts/build.sh` and update `grpc_doc_branch` and `graphql_doc_branch` to a new branch/tag as necessary.
+
+```bash
+cd documentation
+./scripts/build.sh
+```
+
+### Running locally
+
+```console
+yarn serve
+```
+
+### Production build locally
+
+```console
+yarn build
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,6 @@ You can fork the repository and edit your own copy, or propose changes via the G
 The [Docusaurus installation guide](https://docusaurus.io/docs/installation) covers the  software requirements for Docusaurus itself. The following guide walks you through getting the Vega documentation served locally.
 
 ### Requirements
-
 The best way to get the correct version of node is using the `nvm` utility which can be installed from these instructions:
 
 `https://github.com/nvm-sh/nvm#installing-and-updating`

--- a/README.md
+++ b/README.md
@@ -7,101 +7,24 @@ This repo currently includes documentation about the Vega restricted mainnet. Fo
 
 If you have any questions, drop them into Vega's [Discord](https://vega.xyz/discord), [Telegram](https://t.me/vegacommunity), or [Forum](https://community.vega.xyz).
 
-# Docusaurus
+# Software
 
-This website is built using [Docusaurus 2](https://docusaurus.io/).
+This website is built using [Docusaurus 2](https://docusaurus.io/). For more information on how to make changes in this repository, or how to run the site locally, [see CONTRIBUTING.md](./CONTRIBUTING.md).
 
-## Requirements
-For the scripts to work there must be an up to date version of `node` installed along with `yarn`.
-
-The best way to get the correct version of node is using the `nvm` utility which can be installed from these instructions:
-
-`https://github.com/nvm-sh/nvm#installing-and-updating`
-
-Once nvm is installed (check with `nvm --version`) you can run the following command from inside the root of the documentation folder to download and install the correct version of node required by the script:
-
-```
-> nvm install
-> npm --version
-```
-
-`Yarn` can be install by running:
-
-```
-> npm install -g yarn
-> yarn --version
-```
-
-The libraries needed by yarn can be installed by:
-
-```
-> yarn install
-```
-
-Lastly you need to have Python3 installed, you can check if you have by running:
-
-```
-> python3 --version
-```
-
-
-## Installation and local development
-
-Edit `scripts/generate-api-docs.sh` and update `vega_api_branch` to a new branch/tag as necessary.
-
-```console
-cd /path/to/src/github.com/vegaprotocol/documentation
-GITHUB_API_TOKEN=a1b2c3 ./scripts/generate-api-docs.sh
-```
-
-## Running locally
-
-```console
-yarn run serve
-```
-
-# API documentation
-
-## Plugins used
+## Docusaurus plugins
 - [docusaurus-protobuffet](https://www.npmjs.com/package/docusaurus-protobuffet) - Protobuf docs
 - [redocusaurus](https://www.npmjs.com/package/redocusaurus) - REST docs
 - [docusaurus2-graphql-doc-generator](https://www.npmjs.com/package/@edno/docusaurus2-graphql-doc-generator) - GraphQL docs
+- [docusaurus-search-local](https://github.com/easyops-cn/docusaurus-search-local) - 
 
-## Setup
+## Versioning
+All of the text content and API documentation is tied to a release version of the core. To understand how we used Docusaurus versioning, [see VERSIONING.md](./VERSIONING.md).
+
+## Configuration notes
 - GraphQL docs are generated in to `/docs/graphql/`
 - docusaurus-protobuffet-plugin is used to generate docs, but unlike the defaults setup generates them into the `/docs/` so as to avoid documenting them separately
-- New versions of REST docs are configured in `docusaurus.config.js`, as redocusaurus does not generate pages.
+- New versions of REST docs are configured in `docusaurus.config.js`
+- When copying between versions, some files (particularly ones with Ethereum addresses) need to be checked to ensure the [Frontmatter](https://docusaurus.io/docs/markdown-features#front-matter) point to the right networks 
 
-# Versioning
-This site uses [Docusaurus' built in support for versioning](https://docusaurus.io/docs/versioning). This is configured so that:
-
-* */docs/mainnet/* represents the last deployed version on [mainnet](https://blog.vega.xyz/what-to-expect-from-restricted-mainnet-616086d9fdaf)
-* */docs/testnet/* represents the most recent version on [Fairground testnet](https://fairground.wtf)
-
-## Version tags
-In these pre-v1-in-semver times, where version numbers are in the form v(`major.minor.patch`) the versions move when a new *minor* release is deployed to a network. Tagging a version is done [with Docusaurus' `docs:version` command](https://docusaurus.io/docs/versioning#tagging-a-new-version), for example:
-
-```
-yarn run docusaurus docs:version v0.54
-```
-
-This would take a copy of the current docs folder, and make a new folder in `versioned_docs` called `v0.54` with the same content. This mostly works for us, but there are now some manual steps:
-
-### Post tagging: moving labels
-Then in [docusaurus.config.js](https://github.com/vegaprotocol/documentation/blob/main/docusaurus.config.js#L196-L210), the `docs` configuration needs to be updated:
-- `lastVersion` should be set to the version number of `mainnet`
-- The labels and paths should be updated so that the [networks mentioned above](#versioning) line up to their deployed version
-- This will leave older versions without a 'testnet' or 'mainnet' mapping - leave the label and path as the version number
-- Only two releases need to be kept. Older ones can be removed.
-
-### Post tagging: fixing 'absolute' links
-Some of the [API docs generators](#plugins-used) put a full link in the sidebar or documentaiton, rather than relative. There is a script in `scripts/version-switch.sh` that contains some example replacement regexes that will help with this
-
-### Post tagging: adding redocusaurus documents
-Ensure that there are three new redocusaurus configurations in `docusaurus.config.js` that have the correct version label in them.
-
-# Notes
-- Only *the sidebar* and *things in the /docs/ folder* are 'versioned'.
-- Some updates will need to touch old versions as well as the current version
-- Some files (particularly ones with Ethereum addresses) need to be checked to ensure they point to the right networks
-
+# [License](./LICENSE)
+MIT

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,35 @@
+# Versioning
+This site uses [Docusaurus' built in support for versioning](https://docusaurus.io/docs/versioning). This is configured so that:
+
+* */docs/mainnet/* represents the last deployed version on [mainnet](https://blog.vega.xyz/what-to-expect-from-restricted-mainnet-616086d9fdaf)
+* */docs/testnet/* represents the most recent version on [Fairground testnet](https://fairground.wtf)
+
+Both of those do not neccessarily move in lock step. There could be two version updates to one network before the other updates. Bumping a testnet version is easy. Moving a testnet version to mainnet involves the steps below:
+
+## Version tags
+In these pre-v1-in-semver times, where version numbers are in the form v(`major.minor.patch`) the versions move when a new *minor* release is deployed to a network. Tagging a version is done [with Docusaurus' `docs:version` command](https://docusaurus.io/docs/versioning#tagging-a-new-version), for example:
+
+```
+yarn run docusaurus docs:version v0.54
+```
+
+This would take a copy of the current docs folder, and make a new folder in `versioned_docs` called `v0.54` with the same content. This mostly works for us, but there are now some manual steps:
+
+### Post tagging: moving labels
+Then in [docusaurus.config.js](https://github.com/vegaprotocol/documentation/blob/main/docusaurus.config.js#L196-L210), the `docs` configuration needs to be updated:
+- `lastVersion` should be set to the version number of `mainnet`
+- The labels and paths should be updated so that the [networks mentioned above](#versioning) line up to their deployed version
+- This will leave older versions without a 'testnet' or 'mainnet' mapping - leave the label and path as the version number
+- Only two releases need to be kept. Older ones can be removed.
+
+### Post tagging: fixing 'absolute' links
+Some of the [API docs generators](#plugins-used) put a full link in the sidebar or documentaiton, rather than relative. There is a script in `scripts/version-switch.sh` that contains some example replacement regexes that will help with this
+
+### Post tagging: adding redocusaurus documents
+Ensure that there are three new redocusaurus configurations in `docusaurus.config.js` that have the correct version label in them.
+
+# Notes
+- Only *the sidebar* and *things in the /docs/ folder* are 'versioned'.
+- Some updates will need to touch old versions as well as the current version
+- Some files (particularly ones with Ethereum addresses) need to be checked to ensure they point to the right networks
+- `scripts/version-switch.sh` contains some useful commands for ensuring that version changes are made correctly. It isn't quite ready for people unfamiliar with the system, but is commented well and intended to eventually cover most versions.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -23,7 +23,7 @@ Then in [docusaurus.config.js](https://github.com/vegaprotocol/documentation/blo
 - Only two releases need to be kept. Older ones can be removed.
 
 ### Post tagging: fixing 'absolute' links
-Some of the [API docs generators](#plugins-used) put a full link in the sidebar or documentaiton, rather than relative. There is a script in `scripts/version-switch.sh` that contains some example replacement regexes that will help with this
+Some of the [API docs generators](#plugins-used) put a full link in the sidebar or documentation, rather than relative. There is a script in `scripts/version-switch.sh` that contains some example replacement regexes that will help with this
 
 ### Post tagging: adding redocusaurus documents
 Ensure that there are three new redocusaurus configurations in `docusaurus.config.js` that have the correct version label in them.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "postinstall": "touch proto.json",
     "prettier": "prettier --write '*.js' 'src/**/*.js'",
     "docusaurus": "docusaurus",
     "generate-grpc": "mkdir -p docs/grpc && docusaurus generate-proto-docs",


### PR DESCRIPTION
Breaks versioning and local setup out to separate files

This PR adds more details on running Docusaurus locally, which made that section so big that I decided to move it out to a separate file. Then did the same with Versioning. Now the readme is hopefully a little more direct. This replaces #150 which unintentionally included some changes from #111.

