### PR TITLE
Fix/71: Selected item in page nav invisible (same bg/fg colour)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -28,11 +28,15 @@ html[data-theme="dark"] a code {
   color: var(--vega-yellow);
 }
 
+html[data-theme="dark"] a.table-of-contents__link--active code {
+  color: var(--ifm-menu-color-text-active);
+}
+
 html[data-theme="light"] a code {
   background-color: var(--vega-yellow);
 }
 /* Side menu */
- 
+
 .menu__link {
   --ifm-menu-color-background-active: var(--vega-yellow);
   --ifm-menu-color-text-active: #000;


### PR DESCRIPTION
Resolves #71 

Ensures the table of contents submenu code elements have the correct dark text when highlighted and in dark mode.

![Screenshot 2022-08-08 at 14 36 11](https://user-images.githubusercontent.com/2410498/183430990-a2e4e69b-3506-43e2-9715-19c136582a17.png)

