### PR TITLE
Added external link component

### DIFF
--- a/docs/tutorials/staking-tokens.md
+++ b/docs/tutorials/staking-tokens.md
@@ -5,11 +5,12 @@ vega_network: TESTNET
 ethereum_network: Ropsten
 ---
 import EthAddresses from '@site/src/components/EthAddresses';
+import ExtLink from '/src/components/ExternalLinks.js';
 
 
 :::tip
 
-This tutorial describes how to stake via APIs and smart contract integrations. If you're just looking to stake tokens, visit [token.vega.xyz](https://token.vega.xyz)
+This tutorial describes how to stake via APIs and smart contract integrations. If you're just looking to stake tokens, visit <ExtLink href="https://token.vega.xyz">token.vega.xyz</ExtLink>)
 
 :::
 

--- a/src/components/ExternalLinks.js
+++ b/src/components/ExternalLinks.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function Highlight({children, href}) {
+  return (
+    <a
+      href={href}
+      target="_blank">
+      {children} &#8599;
+    </a>
+  );
+}


### PR DESCRIPTION
Added a component to centralise the markup for external links.

For now that this means setting the target to `_blank` and appending an `↗` arrow character. In the future we might want to go further and add a more distinct icon, like external links in [Wikipedia references](https://en.wikipedia.org/wiki/Decentralized_finance#References).

I tried to make it feel like a normal HTML `<a>` tag, so the code to embed an external link is:

`<ExtLink href="https://token.vega.xyz">token.vega.xyz</ExtLink>`

`<ExtLink>` feels clunky. I tried `<a-external>`, hoping it would feel like an extended `<a>` tag, but it seems hyphens aren't allowed. Any ideas for tags that feel intuitive, but aren't too long to type?

I'm also unsure if we should append the arrow in the component file, or append it with CSS.

Adapted from Docusaurus' [Importing components example](https://docusaurus.io/docs/next/markdown-features/react#importing-components).