### PR TITLE
Wallet api v2: fix playground embed

### DIFF
--- a/docs/api/vega-wallet/v2-api/openrpc-api-playground.md
+++ b/docs/api/vega-wallet/v2-api/openrpc-api-playground.md
@@ -2,11 +2,11 @@
 title: API Playground
 hide_title: false
 hide_table_of_contents: true
-sidebar_position: 3 
+sidebar_position: 3
 ---
 
 :::tip
-[Use a full screen view  ↗](https://playground.open-rpc.org/?url=https://raw.githubusercontent.com/vegaprotocol/vega/develop/wallet/api/openrpc.json&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:examplesDropdown]=false)
+[Use a full screen view ↗](https://playground.open-rpc.org/?url=https://raw.githubusercontent.com/vegaprotocol/vega/v0.55.0/wallet/api/openrpc.json&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:examplesDropdown]=false)
 :::
 
-<iframe width="100%" src="https://playground.open-rpc.org/?url=https://raw.githubusercontent.com/vegaprotocol/vega/develop/wallet/api/openrpc.json&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:examplesDropdown]=false" height="700" />
+<iframe width="100%" src="https://playground.open-rpc.org/?url=https://raw.githubusercontent.com/vegaprotocol/vega/v0.55.0/wallet/api/openrpc.json&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:examplesDropdown]=false" height="700" />


### PR DESCRIPTION
Playground embed should point to tagged version of doc, not develop

- Fix embed URL to point to tag, not `develop`

Closes #242
