### PR TITLE
Add asset bridge update

### DIFF
--- a/docs/api/bridge/index.md
+++ b/docs/api/bridge/index.md
@@ -20,7 +20,7 @@ For an introduction to staking on Vega, [check out our Concepts section](../../c
 ## [ERC20 asset bridge](./interfaces/IERC20_Bridge_Logic.md)
 <EthAddresses frontMatter={frontMatter} show={["erc20Bridge"]} />
 
-Used for depositing ERC20 tokens in to a Vega network.
+Used for depositing ERC-20 tokens in to a Vega network.
 
 
 To read more about how the bridge works, [see this blog post](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Ropsten on to the Fairground testnet, head over to [Fairground Console](https://console.fairground.wtf).

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
@@ -2,17 +2,17 @@
   ```javascript
 {
  rationale: {
-  title: "Add USDT Coin (USDT)",
-  description: "Proposal to add USDT Coin (USDT) as an asset"
+  title: "Add Wrapped Ether (WETH)",
+  description: "Proposal to add Wrapped Ether (WETH) as an asset"
  },
  terms: {
   newAsset: {
    changes: {
     // Name of the asset (e.g: Great British Pound) (string) 
-    name: "USDT Coin",
+    name: "Wrapped Ether",
 
     // Symbol of the asset (e.g: GBP) (string) 
-    symbol: "USDT",
+    symbol: "WETH",
 
     // Number of decimal / precision handled by this asset (string) 
     decimals: "18",
@@ -23,7 +23,7 @@
     // An Ethereum ERC20 asset
     erc20: {
      // The address of the contract for the token, on the ethereum network (string)
-     contractAddress: "0xb404c51bbc10dcbe948077f18a4b8e553d160084",
+     contractAddress: "0xc778417e063141139fce010982780140aa0cd5ab",
 
      // The maximum allowed per withdraw
      // note: this is a temporary measure for restricted mainnet (string)
@@ -38,14 +38,14 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1665313779,
+  closingTimestamp: 1666539201,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665400179,
+  enactmentTimestamp: 1666625601,
 
   // Validation timestamp (Unix time in seconds) (int64 as string)
-  validationTimestamp: 1665227379
+  validationTimestamp: 1666452801
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
@@ -2,17 +2,17 @@
   ```javascript
 {
  rationale: {
-  title: "Add Wrapped Ether (WETH)",
-  description: "Proposal to add Wrapped Ether (WETH) as an asset"
+  title: "Add USDT Coin (USDT)",
+  description: "Proposal to add USDT Coin (USDT) as an asset"
  },
  terms: {
   newAsset: {
    changes: {
     // Name of the asset (e.g: Great British Pound) (string) 
-    name: "Wrapped Ether",
+    name: "USDT Coin",
 
     // Symbol of the asset (e.g: GBP) (string) 
-    symbol: "WETH",
+    symbol: "USDT",
 
     // Number of decimal / precision handled by this asset (string) 
     decimals: "18",
@@ -23,7 +23,7 @@
     // An Ethereum ERC20 asset
     erc20: {
      // The address of the contract for the token, on the ethereum network (string)
-     contractAddress: "0xc778417e063141139fce010982780140aa0cd5ab",
+     contractAddress: "0xb404c51bbc10dcbe948077f18a4b8e553d160084",
 
      // The maximum allowed per withdraw
      // note: this is a temporary measure for restricted mainnet (string)
@@ -38,14 +38,14 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1664982989,
+  closingTimestamp: 1665313779,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665069389,
+  enactmentTimestamp: 1665400179,
 
   // Validation timestamp (Unix time in seconds) (int64 as string)
-  validationTimestamp: 1664896589
+  validationTimestamp: 1665227379
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
@@ -2,17 +2,17 @@
   ```javascript
 {
  rationale: {
-  title: "Add Dai Stablecoin (DAI)",
-  description: "Proposal to add Dai Stablecoin (DAI) as an asset"
+  title: "Add Wrapped Ether (WETH)",
+  description: "Proposal to add Wrapped Ether (WETH) as an asset"
  },
  terms: {
   newAsset: {
    changes: {
     // Name of the asset (e.g: Great British Pound) (string) 
-    name: "Dai Stablecoin",
+    name: "Wrapped Ether",
 
     // Symbol of the asset (e.g: GBP) (string) 
-    symbol: "DAI",
+    symbol: "WETH",
 
     // Number of decimal / precision handled by this asset (string) 
     decimals: "18",
@@ -23,7 +23,7 @@
     // An Ethereum ERC20 asset
     erc20: {
      // The address of the contract for the token, on the ethereum network (string)
-     contractAddress: "0x31f42841c2db5173425b5223809cf3a38fede360",
+     contractAddress: "0xc778417e063141139fce010982780140aa0cd5ab",
 
      // The maximum allowed per withdraw
      // note: this is a temporary measure for restricted mainnet (string)
@@ -38,14 +38,14 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1664964291,
+  closingTimestamp: 1664982989,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665050691,
+  enactmentTimestamp: 1665069389,
 
   // Validation timestamp (Unix time in seconds) (int64 as string)
-  validationTimestamp: 1664877891
+  validationTimestamp: 1664896589
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
@@ -2,17 +2,17 @@
   ```javascript
 {
  rationale: {
-  title: "Add USDT Coin (USDT)",
-  description: "Proposal to add USDT Coin (USDT) as an asset"
+  title: "Add Dai Stablecoin (DAI)",
+  description: "Proposal to add Dai Stablecoin (DAI) as an asset"
  },
  terms: {
   newAsset: {
    changes: {
     // Name of the asset (e.g: Great British Pound) (string) 
-    name: "USDT Coin",
+    name: "Dai Stablecoin",
 
     // Symbol of the asset (e.g: GBP) (string) 
-    symbol: "USDT",
+    symbol: "DAI",
 
     // Number of decimal / precision handled by this asset (string) 
     decimals: "18",
@@ -23,7 +23,7 @@
     // An Ethereum ERC20 asset
     erc20: {
      // The address of the contract for the token, on the ethereum network (string)
-     contractAddress: "0xb404c51bbc10dcbe948077f18a4b8e553d160084",
+     contractAddress: "0x31f42841c2db5173425b5223809cf3a38fede360",
 
      // The maximum allowed per withdraw
      // note: this is a temporary measure for restricted mainnet (string)
@@ -38,14 +38,14 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1666044439,
+  closingTimestamp: 1664964291,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1666130839,
+  enactmentTimestamp: 1665050691,
 
   // Validation timestamp (Unix time in seconds) (int64 as string)
-  validationTimestamp: 1665958039
+  validationTimestamp: 1664877891
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
@@ -3,26 +3,26 @@
 ./vegawallet command send --wallet your_walletname --pubkey your_public_key --network fairground '{
  "proposalSubmission": {
   "rationale": {
-   "title": "Add Dai Stablecoin (DAI)",
-   "description": "Proposal to add Dai Stablecoin (DAI) as an asset"
+   "title": "Add Wrapped Ether (WETH)",
+   "description": "Proposal to add Wrapped Ether (WETH) as an asset"
   },
   "terms": {
    "newAsset": {
     "changes": {
-     "name": "Dai Stablecoin",
-     "symbol": "DAI",
+     "name": "Wrapped Ether",
+     "symbol": "WETH",
      "decimals": "18",
      "quantum": "1",
      "erc20": {
-      "contractAddress": "0x31f42841c2db5173425b5223809cf3a38fede360",
+      "contractAddress": "0xc778417e063141139fce010982780140aa0cd5ab",
       "withdrawThreshold": "10",
       "lifetimeLimit": "10"
      }
     }
    },
-   "closingTimestamp": 1664964291,
-   "enactmentTimestamp": 1665050691,
-   "validationTimestamp": 1664877891
+   "closingTimestamp": 1664982989,
+   "enactmentTimestamp": 1665069389,
+   "validationTimestamp": 1664896589
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
@@ -3,26 +3,26 @@
 ./vegawallet command send --wallet your_walletname --pubkey your_public_key --network fairground '{
  "proposalSubmission": {
   "rationale": {
-   "title": "Add USDT Coin (USDT)",
-   "description": "Proposal to add USDT Coin (USDT) as an asset"
+   "title": "Add Dai Stablecoin (DAI)",
+   "description": "Proposal to add Dai Stablecoin (DAI) as an asset"
   },
   "terms": {
    "newAsset": {
     "changes": {
-     "name": "USDT Coin",
-     "symbol": "USDT",
+     "name": "Dai Stablecoin",
+     "symbol": "DAI",
      "decimals": "18",
      "quantum": "1",
      "erc20": {
-      "contractAddress": "0xb404c51bbc10dcbe948077f18a4b8e553d160084",
+      "contractAddress": "0x31f42841c2db5173425b5223809cf3a38fede360",
       "withdrawThreshold": "10",
       "lifetimeLimit": "10"
      }
     }
    },
-   "closingTimestamp": 1666044439,
-   "enactmentTimestamp": 1666130839,
-   "validationTimestamp": 1665958039
+   "closingTimestamp": 1664964291,
+   "enactmentTimestamp": 1665050691,
+   "validationTimestamp": 1664877891
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
@@ -3,26 +3,26 @@
 ./vegawallet command send --wallet your_walletname --pubkey your_public_key --network fairground '{
  "proposalSubmission": {
   "rationale": {
-   "title": "Add Wrapped Ether (WETH)",
-   "description": "Proposal to add Wrapped Ether (WETH) as an asset"
+   "title": "Add USDT Coin (USDT)",
+   "description": "Proposal to add USDT Coin (USDT) as an asset"
   },
   "terms": {
    "newAsset": {
     "changes": {
-     "name": "Wrapped Ether",
-     "symbol": "WETH",
+     "name": "USDT Coin",
+     "symbol": "USDT",
      "decimals": "18",
      "quantum": "1",
      "erc20": {
-      "contractAddress": "0xc778417e063141139fce010982780140aa0cd5ab",
+      "contractAddress": "0xb404c51bbc10dcbe948077f18a4b8e553d160084",
       "withdrawThreshold": "10",
       "lifetimeLimit": "10"
      }
     }
    },
-   "closingTimestamp": 1664982989,
-   "enactmentTimestamp": 1665069389,
-   "validationTimestamp": 1664896589
+   "closingTimestamp": 1665313779,
+   "enactmentTimestamp": 1665400179,
+   "validationTimestamp": 1665227379
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
@@ -3,26 +3,26 @@
 ./vegawallet command send --wallet your_walletname --pubkey your_public_key --network fairground '{
  "proposalSubmission": {
   "rationale": {
-   "title": "Add USDT Coin (USDT)",
-   "description": "Proposal to add USDT Coin (USDT) as an asset"
+   "title": "Add Wrapped Ether (WETH)",
+   "description": "Proposal to add Wrapped Ether (WETH) as an asset"
   },
   "terms": {
    "newAsset": {
     "changes": {
-     "name": "USDT Coin",
-     "symbol": "USDT",
+     "name": "Wrapped Ether",
+     "symbol": "WETH",
      "decimals": "18",
      "quantum": "1",
      "erc20": {
-      "contractAddress": "0xb404c51bbc10dcbe948077f18a4b8e553d160084",
+      "contractAddress": "0xc778417e063141139fce010982780140aa0cd5ab",
       "withdrawThreshold": "10",
       "lifetimeLimit": "10"
      }
     }
    },
-   "closingTimestamp": 1665313779,
-   "enactmentTimestamp": 1665400179,
-   "validationTimestamp": 1665227379
+   "closingTimestamp": 1666539201,
+   "enactmentTimestamp": 1666625601,
+   "validationTimestamp": 1666452801
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
@@ -2,26 +2,26 @@
   ```json
 {
   "rationale": {
-    "title": "Add Wrapped Ether (WETH)",
-    "description": "Proposal to add Wrapped Ether (WETH) as an asset"
+    "title": "Add USDT Coin (USDT)",
+    "description": "Proposal to add USDT Coin (USDT) as an asset"
   },
   "terms": {
     "newAsset": {
       "changes": {
-        "name": "Wrapped Ether",
-        "symbol": "WETH",
+        "name": "USDT Coin",
+        "symbol": "USDT",
         "decimals": "18",
         "quantum": "1",
         "erc20": {
-          "contractAddress": "0xc778417e063141139fce010982780140aa0cd5ab",
+          "contractAddress": "0xb404c51bbc10dcbe948077f18a4b8e553d160084",
           "withdrawThreshold": "10",
           "lifetimeLimit": "10"
         }
       }
     },
-    "closingTimestamp": 1664982989,
-    "enactmentTimestamp": 1665069389,
-    "validationTimestamp": 1664896589
+    "closingTimestamp": 1665313779,
+    "enactmentTimestamp": 1665400179,
+    "validationTimestamp": 1665227379
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
@@ -2,26 +2,26 @@
   ```json
 {
   "rationale": {
-    "title": "Add USDT Coin (USDT)",
-    "description": "Proposal to add USDT Coin (USDT) as an asset"
+    "title": "Add Dai Stablecoin (DAI)",
+    "description": "Proposal to add Dai Stablecoin (DAI) as an asset"
   },
   "terms": {
     "newAsset": {
       "changes": {
-        "name": "USDT Coin",
-        "symbol": "USDT",
+        "name": "Dai Stablecoin",
+        "symbol": "DAI",
         "decimals": "18",
         "quantum": "1",
         "erc20": {
-          "contractAddress": "0xb404c51bbc10dcbe948077f18a4b8e553d160084",
+          "contractAddress": "0x31f42841c2db5173425b5223809cf3a38fede360",
           "withdrawThreshold": "10",
           "lifetimeLimit": "10"
         }
       }
     },
-    "closingTimestamp": 1666044439,
-    "enactmentTimestamp": 1666130839,
-    "validationTimestamp": 1665958039
+    "closingTimestamp": 1664964291,
+    "enactmentTimestamp": 1665050691,
+    "validationTimestamp": 1664877891
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
@@ -2,26 +2,26 @@
   ```json
 {
   "rationale": {
-    "title": "Add Dai Stablecoin (DAI)",
-    "description": "Proposal to add Dai Stablecoin (DAI) as an asset"
+    "title": "Add Wrapped Ether (WETH)",
+    "description": "Proposal to add Wrapped Ether (WETH) as an asset"
   },
   "terms": {
     "newAsset": {
       "changes": {
-        "name": "Dai Stablecoin",
-        "symbol": "DAI",
+        "name": "Wrapped Ether",
+        "symbol": "WETH",
         "decimals": "18",
         "quantum": "1",
         "erc20": {
-          "contractAddress": "0x31f42841c2db5173425b5223809cf3a38fede360",
+          "contractAddress": "0xc778417e063141139fce010982780140aa0cd5ab",
           "withdrawThreshold": "10",
           "lifetimeLimit": "10"
         }
       }
     },
-    "closingTimestamp": 1664964291,
-    "enactmentTimestamp": 1665050691,
-    "validationTimestamp": 1664877891
+    "closingTimestamp": 1664982989,
+    "enactmentTimestamp": 1665069389,
+    "validationTimestamp": 1664896589
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
@@ -2,26 +2,26 @@
   ```json
 {
   "rationale": {
-    "title": "Add USDT Coin (USDT)",
-    "description": "Proposal to add USDT Coin (USDT) as an asset"
+    "title": "Add Wrapped Ether (WETH)",
+    "description": "Proposal to add Wrapped Ether (WETH) as an asset"
   },
   "terms": {
     "newAsset": {
       "changes": {
-        "name": "USDT Coin",
-        "symbol": "USDT",
+        "name": "Wrapped Ether",
+        "symbol": "WETH",
         "decimals": "18",
         "quantum": "1",
         "erc20": {
-          "contractAddress": "0xb404c51bbc10dcbe948077f18a4b8e553d160084",
+          "contractAddress": "0xc778417e063141139fce010982780140aa0cd5ab",
           "withdrawThreshold": "10",
           "lifetimeLimit": "10"
         }
       }
     },
-    "closingTimestamp": 1665313779,
-    "enactmentTimestamp": 1665400179,
-    "validationTimestamp": 1665227379
+    "closingTimestamp": 1666539201,
+    "enactmentTimestamp": 1666625601,
+    "validationTimestamp": 1666452801
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
@@ -4,26 +4,26 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
 "{^
 \"proposalSubmission\": {^
  \"rationale\": {^
-  \"title\": \"Add USDT Coin (USDT)\",^
-  \"description\": \"Proposal to add USDT Coin (USDT) as an asset\"^
+  \"title\": \"Add Wrapped Ether (WETH)\",^
+  \"description\": \"Proposal to add Wrapped Ether (WETH) as an asset\"^
  },^
  \"terms\": {^
   \"newAsset\": {^
    \"changes\": {^
-    \"name\": \"USDT Coin\",^
-    \"symbol\": \"USDT\",^
+    \"name\": \"Wrapped Ether\",^
+    \"symbol\": \"WETH\",^
     \"decimals\": \"18\",^
     \"quantum\": \"1\",^
     \"erc20\": {^
-     \"contractAddress\": \"0xb404c51bbc10dcbe948077f18a4b8e553d160084\",^
+     \"contractAddress\": \"0xc778417e063141139fce010982780140aa0cd5ab\",^
      \"withdrawThreshold\": \"10\",^
      \"lifetimeLimit\": \"10\"^
     }^
    }^
   },^
-  \"closingTimestamp\": 1665313779,^
-  \"enactmentTimestamp\": 1665400179,^
-  \"validationTimestamp\": 1665227379^
+  \"closingTimestamp\": 1666539201,^
+  \"enactmentTimestamp\": 1666625601,^
+  \"validationTimestamp\": 1666452801^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
@@ -4,26 +4,26 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
 "{^
 \"proposalSubmission\": {^
  \"rationale\": {^
-  \"title\": \"Add USDT Coin (USDT)\",^
-  \"description\": \"Proposal to add USDT Coin (USDT) as an asset\"^
+  \"title\": \"Add Dai Stablecoin (DAI)\",^
+  \"description\": \"Proposal to add Dai Stablecoin (DAI) as an asset\"^
  },^
  \"terms\": {^
   \"newAsset\": {^
    \"changes\": {^
-    \"name\": \"USDT Coin\",^
-    \"symbol\": \"USDT\",^
+    \"name\": \"Dai Stablecoin\",^
+    \"symbol\": \"DAI\",^
     \"decimals\": \"18\",^
     \"quantum\": \"1\",^
     \"erc20\": {^
-     \"contractAddress\": \"0xb404c51bbc10dcbe948077f18a4b8e553d160084\",^
+     \"contractAddress\": \"0x31f42841c2db5173425b5223809cf3a38fede360\",^
      \"withdrawThreshold\": \"10\",^
      \"lifetimeLimit\": \"10\"^
     }^
    }^
   },^
-  \"closingTimestamp\": 1666044439,^
-  \"enactmentTimestamp\": 1666130839,^
-  \"validationTimestamp\": 1665958039^
+  \"closingTimestamp\": 1664964291,^
+  \"enactmentTimestamp\": 1665050691,^
+  \"validationTimestamp\": 1664877891^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
@@ -4,26 +4,26 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
 "{^
 \"proposalSubmission\": {^
  \"rationale\": {^
-  \"title\": \"Add Dai Stablecoin (DAI)\",^
-  \"description\": \"Proposal to add Dai Stablecoin (DAI) as an asset\"^
+  \"title\": \"Add Wrapped Ether (WETH)\",^
+  \"description\": \"Proposal to add Wrapped Ether (WETH) as an asset\"^
  },^
  \"terms\": {^
   \"newAsset\": {^
    \"changes\": {^
-    \"name\": \"Dai Stablecoin\",^
-    \"symbol\": \"DAI\",^
+    \"name\": \"Wrapped Ether\",^
+    \"symbol\": \"WETH\",^
     \"decimals\": \"18\",^
     \"quantum\": \"1\",^
     \"erc20\": {^
-     \"contractAddress\": \"0x31f42841c2db5173425b5223809cf3a38fede360\",^
+     \"contractAddress\": \"0xc778417e063141139fce010982780140aa0cd5ab\",^
      \"withdrawThreshold\": \"10\",^
      \"lifetimeLimit\": \"10\"^
     }^
    }^
   },^
-  \"closingTimestamp\": 1664964291,^
-  \"enactmentTimestamp\": 1665050691,^
-  \"validationTimestamp\": 1664877891^
+  \"closingTimestamp\": 1664982989,^
+  \"enactmentTimestamp\": 1665069389,^
+  \"validationTimestamp\": 1664896589^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
@@ -4,26 +4,26 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
 "{^
 \"proposalSubmission\": {^
  \"rationale\": {^
-  \"title\": \"Add Wrapped Ether (WETH)\",^
-  \"description\": \"Proposal to add Wrapped Ether (WETH) as an asset\"^
+  \"title\": \"Add USDT Coin (USDT)\",^
+  \"description\": \"Proposal to add USDT Coin (USDT) as an asset\"^
  },^
  \"terms\": {^
   \"newAsset\": {^
    \"changes\": {^
-    \"name\": \"Wrapped Ether\",^
-    \"symbol\": \"WETH\",^
+    \"name\": \"USDT Coin\",^
+    \"symbol\": \"USDT\",^
     \"decimals\": \"18\",^
     \"quantum\": \"1\",^
     \"erc20\": {^
-     \"contractAddress\": \"0xc778417e063141139fce010982780140aa0cd5ab\",^
+     \"contractAddress\": \"0xb404c51bbc10dcbe948077f18a4b8e553d160084\",^
      \"withdrawThreshold\": \"10\",^
      \"lifetimeLimit\": \"10\"^
     }^
    }^
   },^
-  \"closingTimestamp\": 1664982989,^
-  \"enactmentTimestamp\": 1665069389,^
-  \"validationTimestamp\": 1664896589^
+  \"closingTimestamp\": 1665313779,^
+  \"enactmentTimestamp\": 1665400179,^
+  \"validationTimestamp\": 1665227379^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
@@ -13,7 +13,7 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string})
-  closingTimestamp: 1664964291,
+  closingTimestamp: 1664982989,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
@@ -13,7 +13,7 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string})
-  closingTimestamp: 1664982989,
+  closingTimestamp: 1665313779,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
@@ -13,7 +13,7 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string})
-  closingTimestamp: 1665313779,
+  closingTimestamp: 1666539201,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
@@ -13,7 +13,7 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string})
-  closingTimestamp: 1666044439,
+  closingTimestamp: 1664964291,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
@@ -8,7 +8,7 @@
   },
   "terms": {
    "newFreeform": {},
-   "closingTimestamp": 1666044439
+   "closingTimestamp": 1664964291
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
@@ -8,7 +8,7 @@
   },
   "terms": {
    "newFreeform": {},
-   "closingTimestamp": 1665313779
+   "closingTimestamp": 1666539201
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
@@ -8,7 +8,7 @@
   },
   "terms": {
    "newFreeform": {},
-   "closingTimestamp": 1664964291
+   "closingTimestamp": 1664982989
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
@@ -8,7 +8,7 @@
   },
   "terms": {
    "newFreeform": {},
-   "closingTimestamp": 1664982989
+   "closingTimestamp": 1665313779
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
@@ -7,7 +7,7 @@
   },
   "terms": {
     "newFreeform": {},
-    "closingTimestamp": 1664982989
+    "closingTimestamp": 1665313779
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
@@ -7,7 +7,7 @@
   },
   "terms": {
     "newFreeform": {},
-    "closingTimestamp": 1665313779
+    "closingTimestamp": 1666539201
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
@@ -7,7 +7,7 @@
   },
   "terms": {
     "newFreeform": {},
-    "closingTimestamp": 1664964291
+    "closingTimestamp": 1664982989
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
@@ -7,7 +7,7 @@
   },
   "terms": {
     "newFreeform": {},
-    "closingTimestamp": 1666044439
+    "closingTimestamp": 1664964291
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
@@ -9,7 +9,7 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
  },^
  \"terms\": {^
   \"newFreeform\": {},^
-  \"closingTimestamp\": 1664982989^
+  \"closingTimestamp\": 1665313779^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
@@ -9,7 +9,7 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
  },^
  \"terms\": {^
   \"newFreeform\": {},^
-  \"closingTimestamp\": 1664964291^
+  \"closingTimestamp\": 1664982989^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
@@ -9,7 +9,7 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
  },^
  \"terms\": {^
   \"newFreeform\": {},^
-  \"closingTimestamp\": 1665313779^
+  \"closingTimestamp\": 1666539201^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
@@ -9,7 +9,7 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
  },^
  \"terms\": {^
   \"newFreeform\": {},^
-  \"closingTimestamp\": 1666044439^
+  \"closingTimestamp\": 1664964291^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
@@ -17,10 +17,10 @@
     // New market instrument configuration
     instrument: {
      // Instrument name
-     name: "Oranges Daily",
+     name: "Apples Yearly (2022)",
 
      // Instrument code, human-readable shortcode used to describe the instrument
-     code: "ORANGES.24h",
+     code: "APPLES.22",
 
      // Future
      future: {
@@ -30,8 +30,8 @@
       // Product quote name (string)
       quoteName: "tEuro",
 
-      // The number of decimal places implied by the settlement data (such as price) emitted by the settlement oracle (int64 as integer)
-      settlementDataDecimals: 5,
+      // The number of decimal places implied by the settlement price emitted by the settlement oracle (int64 as integer)
+      settlementPriceDecimals: 5,
 
       // The oracle spec describing the oracle data of settlement price (object)
       oracleSpecForSettlementPrice: {
@@ -122,8 +122,7 @@
 
      // Optional new market meta data, tags
      metadata: [
-      "sector:food",
-      "sector:materials",
+      "sector:health",
       "source:docs.vega.xyz"
      ],
 
@@ -171,7 +170,7 @@
      tau: 0.0001140771161,
 
      // Risk Aversion Parameter (double as number) 
-     riskAversionParameter: "0.001",
+     riskAversionParameter: "0.01",
 
      // Risk model parameters for log normal
      params: {
@@ -182,7 +181,7 @@
       r: 0.016,
 
       // Sigma param (double as number) 
-      sigma: 0.8,
+      sigma: 1.25,
      }
     },
    }
@@ -190,11 +189,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1666044439,
+  closingTimestamp: 1664964291,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1666130839,
+  enactmentTimestamp: 1665050691,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
@@ -122,6 +122,8 @@
 
      // Optional new market meta data, tags
      metadata: [
+      "sector:food",
+      "sector:energy",
       "sector:health",
       "source:docs.vega.xyz"
      ],
@@ -170,7 +172,7 @@
      tau: 0.0001140771161,
 
      // Risk Aversion Parameter (double as number) 
-     riskAversionParameter: "0.01",
+     riskAversionParameter: "0.0001",
 
      // Risk model parameters for log normal
      params: {
@@ -181,7 +183,7 @@
       r: 0.016,
 
       // Sigma param (double as number) 
-      sigma: 1.25,
+      sigma: 0.5,
      }
     },
    }
@@ -189,11 +191,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1664964291,
+  closingTimestamp: 1664982989,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665050691,
+  enactmentTimestamp: 1665069389,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
@@ -17,10 +17,10 @@
     // New market instrument configuration
     instrument: {
      // Instrument name
-     name: "Apples Yearly (2022)",
+     name: "Oranges Daily",
 
      // Instrument code, human-readable shortcode used to describe the instrument
-     code: "APPLES.22",
+     code: "ORANGES.24h",
 
      // Future
      future: {
@@ -124,7 +124,6 @@
      metadata: [
       "sector:food",
       "sector:energy",
-      "sector:health",
       "source:docs.vega.xyz"
      ],
 
@@ -183,7 +182,7 @@
       r: 0.016,
 
       // Sigma param (double as number) 
-      sigma: 0.5,
+      sigma: 0.8,
      }
     },
    }
@@ -191,11 +190,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1664982989,
+  closingTimestamp: 1665313779,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665069389,
+  enactmentTimestamp: 1665400179,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
@@ -30,8 +30,8 @@
       // Product quote name (string)
       quoteName: "tEuro",
 
-      // The number of decimal places implied by the settlement price emitted by the settlement oracle (int64 as integer)
-      settlementPriceDecimals: 5,
+      // The number of decimal places implied by the settlement data (such as price) emitted by the settlement oracle (int64 as integer)
+      settlementDataDecimals: 5,
 
       // The oracle spec describing the oracle data of settlement price (object)
       oracleSpecForSettlementPrice: {
@@ -122,8 +122,8 @@
 
      // Optional new market meta data, tags
      metadata: [
+      "sector:tech",
       "sector:food",
-      "sector:energy",
       "source:docs.vega.xyz"
      ],
 
@@ -182,7 +182,7 @@
       r: 0.016,
 
       // Sigma param (double as number) 
-      sigma: 0.8,
+      sigma: 1.25,
      }
     },
    }
@@ -190,11 +190,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1665313779,
+  closingTimestamp: 1666539201,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665400179,
+  enactmentTimestamp: 1666625601,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
@@ -12,8 +12,8 @@
      "decimalPlaces": "5",
      "positionDecimalPlaces": "5",
      "instrument": {
-      "name": "Apples Yearly (2022)",
-      "code": "APPLES.22",
+      "name": "Oranges Daily",
+      "code": "ORANGES.24h",
       "future": {
        "settlementAsset": "8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4",
        "quoteName": "tEuro",
@@ -65,7 +65,6 @@
      "metadata": [
       "sector:food",
       "sector:energy",
-      "sector:health",
       "source:docs.vega.xyz"
      ],
      "priceMonitoringParameters": {
@@ -91,13 +90,13 @@
       "params": {
        "mu": 0,
        "r": 0.016,
-       "sigma": 0.5
+       "sigma": 0.8
       }
      }
     }
    },
-   "closingTimestamp": 1664982989,
-   "enactmentTimestamp": 1665069389
+   "closingTimestamp": 1665313779,
+   "enactmentTimestamp": 1665400179
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
@@ -12,12 +12,12 @@
      "decimalPlaces": "5",
      "positionDecimalPlaces": "5",
      "instrument": {
-      "name": "Oranges Daily",
-      "code": "ORANGES.24h",
+      "name": "Apples Yearly (2022)",
+      "code": "APPLES.22",
       "future": {
        "settlementAsset": "8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4",
        "quoteName": "tEuro",
-       "settlementDataDecimals": 5,
+       "settlementPriceDecimals": 5,
        "oracleSpecForSettlementPrice": {
         "pubKeys": [
          "0xfCEAdAFab14d46e20144F48824d0C09B1a03F2BC"
@@ -63,8 +63,7 @@
       }
      },
      "metadata": [
-      "sector:food",
-      "sector:materials",
+      "sector:health",
       "source:docs.vega.xyz"
      ],
      "priceMonitoringParameters": {
@@ -86,17 +85,17 @@
      },
      "logNormal": {
       "tau": 0.0001140771161,
-      "riskAversionParameter": 0.001,
+      "riskAversionParameter": 0.01,
       "params": {
        "mu": 0,
        "r": 0.016,
-       "sigma": 0.8
+       "sigma": 1.25
       }
      }
     }
    },
-   "closingTimestamp": 1666044439,
-   "enactmentTimestamp": 1666130839
+   "closingTimestamp": 1664964291,
+   "enactmentTimestamp": 1665050691
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
@@ -63,6 +63,8 @@
       }
      },
      "metadata": [
+      "sector:food",
+      "sector:energy",
       "sector:health",
       "source:docs.vega.xyz"
      ],
@@ -85,17 +87,17 @@
      },
      "logNormal": {
       "tau": 0.0001140771161,
-      "riskAversionParameter": 0.01,
+      "riskAversionParameter": 0.0001,
       "params": {
        "mu": 0,
        "r": 0.016,
-       "sigma": 1.25
+       "sigma": 0.5
       }
      }
     }
    },
-   "closingTimestamp": 1664964291,
-   "enactmentTimestamp": 1665050691
+   "closingTimestamp": 1664982989,
+   "enactmentTimestamp": 1665069389
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
@@ -17,7 +17,7 @@
       "future": {
        "settlementAsset": "8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4",
        "quoteName": "tEuro",
-       "settlementPriceDecimals": 5,
+       "settlementDataDecimals": 5,
        "oracleSpecForSettlementPrice": {
         "pubKeys": [
          "0xfCEAdAFab14d46e20144F48824d0C09B1a03F2BC"
@@ -63,8 +63,8 @@
       }
      },
      "metadata": [
+      "sector:tech",
       "sector:food",
-      "sector:energy",
       "source:docs.vega.xyz"
      ],
      "priceMonitoringParameters": {
@@ -90,13 +90,13 @@
       "params": {
        "mu": 0,
        "r": 0.016,
-       "sigma": 0.8
+       "sigma": 1.25
       }
      }
     }
    },
-   "closingTimestamp": 1665313779,
-   "enactmentTimestamp": 1665400179
+   "closingTimestamp": 1666539201,
+   "enactmentTimestamp": 1666625601
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
@@ -11,12 +11,12 @@
         "decimalPlaces": "5",
         "positionDecimalPlaces": "5",
         "instrument": {
-          "name": "Oranges Daily",
-          "code": "ORANGES.24h",
+          "name": "Apples Yearly (2022)",
+          "code": "APPLES.22",
           "future": {
             "settlementAsset": "8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4",
             "quoteName": "tEuro",
-            "settlementDataDecimals": 5,
+            "settlementPriceDecimals": 5,
             "oracleSpecForSettlementPrice": {
               "pubKeys": [
                 "0xfCEAdAFab14d46e20144F48824d0C09B1a03F2BC"
@@ -62,8 +62,7 @@
           }
         },
         "metadata": [
-          "sector:food",
-          "sector:materials",
+          "sector:health",
           "source:docs.vega.xyz"
         ],
         "priceMonitoringParameters": {
@@ -85,17 +84,17 @@
         },
         "logNormal": {
           "tau": 0.0001140771161,
-          "riskAversionParameter": 0.001,
+          "riskAversionParameter": 0.01,
           "params": {
             "mu": 0,
             "r": 0.016,
-            "sigma": 0.8
+            "sigma": 1.25
           }
         }
       }
     },
-    "closingTimestamp": 1666044439,
-    "enactmentTimestamp": 1666130839
+    "closingTimestamp": 1664964291,
+    "enactmentTimestamp": 1665050691
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
@@ -11,8 +11,8 @@
         "decimalPlaces": "5",
         "positionDecimalPlaces": "5",
         "instrument": {
-          "name": "Apples Yearly (2022)",
-          "code": "APPLES.22",
+          "name": "Oranges Daily",
+          "code": "ORANGES.24h",
           "future": {
             "settlementAsset": "8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4",
             "quoteName": "tEuro",
@@ -64,7 +64,6 @@
         "metadata": [
           "sector:food",
           "sector:energy",
-          "sector:health",
           "source:docs.vega.xyz"
         ],
         "priceMonitoringParameters": {
@@ -90,13 +89,13 @@
           "params": {
             "mu": 0,
             "r": 0.016,
-            "sigma": 0.5
+            "sigma": 0.8
           }
         }
       }
     },
-    "closingTimestamp": 1664982989,
-    "enactmentTimestamp": 1665069389
+    "closingTimestamp": 1665313779,
+    "enactmentTimestamp": 1665400179
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
@@ -16,7 +16,7 @@
           "future": {
             "settlementAsset": "8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4",
             "quoteName": "tEuro",
-            "settlementPriceDecimals": 5,
+            "settlementDataDecimals": 5,
             "oracleSpecForSettlementPrice": {
               "pubKeys": [
                 "0xfCEAdAFab14d46e20144F48824d0C09B1a03F2BC"
@@ -62,8 +62,8 @@
           }
         },
         "metadata": [
+          "sector:tech",
           "sector:food",
-          "sector:energy",
           "source:docs.vega.xyz"
         ],
         "priceMonitoringParameters": {
@@ -89,13 +89,13 @@
           "params": {
             "mu": 0,
             "r": 0.016,
-            "sigma": 0.8
+            "sigma": 1.25
           }
         }
       }
     },
-    "closingTimestamp": 1665313779,
-    "enactmentTimestamp": 1665400179
+    "closingTimestamp": 1666539201,
+    "enactmentTimestamp": 1666625601
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
@@ -62,6 +62,8 @@
           }
         },
         "metadata": [
+          "sector:food",
+          "sector:energy",
           "sector:health",
           "source:docs.vega.xyz"
         ],
@@ -84,17 +86,17 @@
         },
         "logNormal": {
           "tau": 0.0001140771161,
-          "riskAversionParameter": 0.01,
+          "riskAversionParameter": 0.0001,
           "params": {
             "mu": 0,
             "r": 0.016,
-            "sigma": 1.25
+            "sigma": 0.5
           }
         }
       }
     },
-    "closingTimestamp": 1664964291,
-    "enactmentTimestamp": 1665050691
+    "closingTimestamp": 1664982989,
+    "enactmentTimestamp": 1665069389
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
@@ -25,10 +25,10 @@
   },
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1666044439,
+  closingTimestamp: 1664964291,
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1666130839,
+  enactmentTimestamp: 1665050691,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
@@ -25,10 +25,10 @@
   },
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1664982989,
+  closingTimestamp: 1665313779,
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665069389,
+  enactmentTimestamp: 1665400179,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
@@ -25,10 +25,10 @@
   },
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1664964291,
+  closingTimestamp: 1664982989,
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665050691,
+  enactmentTimestamp: 1665069389,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
@@ -25,10 +25,10 @@
   },
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1665313779,
+  closingTimestamp: 1666539201,
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665400179,
+  enactmentTimestamp: 1666625601,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
@@ -13,8 +13,8 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
     \"decimalPlaces\": \"5\",^
     \"positionDecimalPlaces\": \"5\",^
     \"instrument\": {^
-     \"name\": \"Apples Yearly (2022)\",^
-     \"code\": \"APPLES.22\",^
+     \"name\": \"Oranges Daily\",^
+     \"code\": \"ORANGES.24h\",^
      \"future\": {^
       \"settlementAsset\": \"8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4\",^
       \"quoteName\": \"tEuro\",^
@@ -66,7 +66,6 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
     \"metadata\": [^
      \"sector:food\",^
      \"sector:energy\",^
-     \"sector:health\",^
      \"source:docs.vega.xyz\"^
     ],^
     \"priceMonitoringParameters\": {^
@@ -92,13 +91,13 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
-      \"sigma\": 0.5^
+      \"sigma\": 0.8^
      }^
     }^
    }^
   },^
-  \"closingTimestamp\": 1664982989,^
-  \"enactmentTimestamp\": 1665069389^
+  \"closingTimestamp\": 1665313779,^
+  \"enactmentTimestamp\": 1665400179^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
@@ -13,12 +13,12 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
     \"decimalPlaces\": \"5\",^
     \"positionDecimalPlaces\": \"5\",^
     \"instrument\": {^
-     \"name\": \"Oranges Daily\",^
-     \"code\": \"ORANGES.24h\",^
+     \"name\": \"Apples Yearly (2022)\",^
+     \"code\": \"APPLES.22\",^
      \"future\": {^
       \"settlementAsset\": \"8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4\",^
       \"quoteName\": \"tEuro\",^
-      \"settlementDataDecimals\": 5,^
+      \"settlementPriceDecimals\": 5,^
       \"oracleSpecForSettlementPrice\": {^
        \"pubKeys\": [^
         \"0xfCEAdAFab14d46e20144F48824d0C09B1a03F2BC\"^
@@ -64,8 +64,7 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
      }^
     },^
     \"metadata\": [^
-     \"sector:food\",^
-     \"sector:materials\",^
+     \"sector:health\",^
      \"source:docs.vega.xyz\"^
     ],^
     \"priceMonitoringParameters\": {^
@@ -87,17 +86,17 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
     },^
     \"logNormal\": {^
      \"tau\": 0.0001140771161,^
-     \"riskAversionParameter\": 0.001,^
+     \"riskAversionParameter\": 0.01,^
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
-      \"sigma\": 0.8^
+      \"sigma\": 1.25^
      }^
     }^
    }^
   },^
-  \"closingTimestamp\": 1666044439,^
-  \"enactmentTimestamp\": 1666130839^
+  \"closingTimestamp\": 1664964291,^
+  \"enactmentTimestamp\": 1665050691^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
@@ -18,7 +18,7 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
      \"future\": {^
       \"settlementAsset\": \"8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4\",^
       \"quoteName\": \"tEuro\",^
-      \"settlementPriceDecimals\": 5,^
+      \"settlementDataDecimals\": 5,^
       \"oracleSpecForSettlementPrice\": {^
        \"pubKeys\": [^
         \"0xfCEAdAFab14d46e20144F48824d0C09B1a03F2BC\"^
@@ -64,8 +64,8 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
      }^
     },^
     \"metadata\": [^
+     \"sector:tech\",^
      \"sector:food\",^
-     \"sector:energy\",^
      \"source:docs.vega.xyz\"^
     ],^
     \"priceMonitoringParameters\": {^
@@ -91,13 +91,13 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
-      \"sigma\": 0.8^
+      \"sigma\": 1.25^
      }^
     }^
    }^
   },^
-  \"closingTimestamp\": 1665313779,^
-  \"enactmentTimestamp\": 1665400179^
+  \"closingTimestamp\": 1666539201,^
+  \"enactmentTimestamp\": 1666625601^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
@@ -64,6 +64,8 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
      }^
     },^
     \"metadata\": [^
+     \"sector:food\",^
+     \"sector:energy\",^
      \"sector:health\",^
      \"source:docs.vega.xyz\"^
     ],^
@@ -86,17 +88,17 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
     },^
     \"logNormal\": {^
      \"tau\": 0.0001140771161,^
-     \"riskAversionParameter\": 0.01,^
+     \"riskAversionParameter\": 0.0001,^
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
-      \"sigma\": 1.25^
+      \"sigma\": 0.5^
      }^
     }^
    }^
   },^
-  \"closingTimestamp\": 1664964291,^
-  \"enactmentTimestamp\": 1665050691^
+  \"closingTimestamp\": 1664982989,^
+  \"enactmentTimestamp\": 1665069389^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
@@ -24,11 +24,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1665313779,
+  closingTimestamp: 1666539201,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665400179,
+  enactmentTimestamp: 1666625601,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
@@ -8,10 +8,8 @@
  terms: {
   updateAsset: {
    changes: {
-    // The minimum economically meaningful amount in the asset (string)
-    quantum: "1",
     erc20: {
-     // The maximum allowed per withdraw.
+     // The lifetime limits deposit per address.
      // This is will be interpreted against the asset decimals. (string)
      withdrawThreshold: "10",
 
@@ -24,11 +22,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1666044439,
+  closingTimestamp: 1664964291,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1666130839,
+  enactmentTimestamp: 1665050691,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
@@ -8,6 +8,8 @@
  terms: {
   updateAsset: {
    changes: {
+    // The minimum economically meaningful amount in the asset (string)
+    quantum: "1",
     erc20: {
      // The lifetime limits deposit per address.
      // This is will be interpreted against the asset decimals. (string)
@@ -22,11 +24,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1664964291,
+  closingTimestamp: 1664982989,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665050691,
+  enactmentTimestamp: 1665069389,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
@@ -11,7 +11,7 @@
     // The minimum economically meaningful amount in the asset (string)
     quantum: "1",
     erc20: {
-     // The lifetime limits deposit per address.
+     // The maximum allowed per withdraw.
      // This is will be interpreted against the asset decimals. (string)
      withdrawThreshold: "10",
 
@@ -24,11 +24,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1664982989,
+  closingTimestamp: 1665313779,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665069389,
+  enactmentTimestamp: 1665400179,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
@@ -8,15 +8,17 @@
   },
   "terms": {
    "updateAsset": {
+    "assetId": "ebcd94151ae1f0d39a4bde3b21a9c7ae81a80ea4352fb075a92e07608d9c953d",
     "changes": {
+     "quantum": "1",
      "erc20": {
       "withdrawThreshold": "10",
       "lifetimeLimit": "10"
      }
     }
    },
-   "closingTimestamp": 1664964291,
-   "enactmentTimestamp": 1665050691
+   "closingTimestamp": 1664982989,
+   "enactmentTimestamp": 1665069389
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
@@ -17,8 +17,8 @@
      }
     }
    },
-   "closingTimestamp": 1664982989,
-   "enactmentTimestamp": 1665069389
+   "closingTimestamp": 1665313779,
+   "enactmentTimestamp": 1665400179
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
@@ -8,17 +8,15 @@
   },
   "terms": {
    "updateAsset": {
-    "assetId": "ebcd94151ae1f0d39a4bde3b21a9c7ae81a80ea4352fb075a92e07608d9c953d",
     "changes": {
-     "quantum": "1",
      "erc20": {
       "withdrawThreshold": "10",
       "lifetimeLimit": "10"
      }
     }
    },
-   "closingTimestamp": 1666044439,
-   "enactmentTimestamp": 1666130839
+   "closingTimestamp": 1664964291,
+   "enactmentTimestamp": 1665050691
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
@@ -17,8 +17,8 @@
      }
     }
    },
-   "closingTimestamp": 1665313779,
-   "enactmentTimestamp": 1665400179
+   "closingTimestamp": 1666539201,
+   "enactmentTimestamp": 1666625601
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
@@ -16,8 +16,8 @@
         }
       }
     },
-    "closingTimestamp": 1665313779,
-    "enactmentTimestamp": 1665400179
+    "closingTimestamp": 1666539201,
+    "enactmentTimestamp": 1666625601
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
@@ -16,8 +16,8 @@
         }
       }
     },
-    "closingTimestamp": 1664982989,
-    "enactmentTimestamp": 1665069389
+    "closingTimestamp": 1665313779,
+    "enactmentTimestamp": 1665400179
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
@@ -7,15 +7,17 @@
   },
   "terms": {
     "updateAsset": {
+      "assetId": "ebcd94151ae1f0d39a4bde3b21a9c7ae81a80ea4352fb075a92e07608d9c953d",
       "changes": {
+        "quantum": "1",
         "erc20": {
           "withdrawThreshold": "10",
           "lifetimeLimit": "10"
         }
       }
     },
-    "closingTimestamp": 1664964291,
-    "enactmentTimestamp": 1665050691
+    "closingTimestamp": 1664982989,
+    "enactmentTimestamp": 1665069389
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
@@ -7,17 +7,15 @@
   },
   "terms": {
     "updateAsset": {
-      "assetId": "ebcd94151ae1f0d39a4bde3b21a9c7ae81a80ea4352fb075a92e07608d9c953d",
       "changes": {
-        "quantum": "1",
         "erc20": {
           "withdrawThreshold": "10",
           "lifetimeLimit": "10"
         }
       }
     },
-    "closingTimestamp": 1666044439,
-    "enactmentTimestamp": 1666130839
+    "closingTimestamp": 1664964291,
+    "enactmentTimestamp": 1665050691
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
@@ -18,8 +18,8 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
     }^
    }^
   },^
-  \"closingTimestamp\": 1664982989,^
-  \"enactmentTimestamp\": 1665069389^
+  \"closingTimestamp\": 1665313779,^
+  \"enactmentTimestamp\": 1665400179^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
@@ -18,8 +18,8 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
     }^
    }^
   },^
-  \"closingTimestamp\": 1665313779,^
-  \"enactmentTimestamp\": 1665400179^
+  \"closingTimestamp\": 1666539201,^
+  \"enactmentTimestamp\": 1666625601^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
@@ -9,17 +9,15 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
  },^
  \"terms\": {^
   \"updateAsset\": {^
-   \"assetId\": \"ebcd94151ae1f0d39a4bde3b21a9c7ae81a80ea4352fb075a92e07608d9c953d\",^
    \"changes\": {^
-    \"quantum\": \"1\",^
     \"erc20\": {^
      \"withdrawThreshold\": \"10\",^
      \"lifetimeLimit\": \"10\"^
     }^
    }^
   },^
-  \"closingTimestamp\": 1666044439,^
-  \"enactmentTimestamp\": 1666130839^
+  \"closingTimestamp\": 1664964291,^
+  \"enactmentTimestamp\": 1665050691^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
@@ -9,15 +9,17 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
  },^
  \"terms\": {^
   \"updateAsset\": {^
+   \"assetId\": \"ebcd94151ae1f0d39a4bde3b21a9c7ae81a80ea4352fb075a92e07608d9c953d\",^
    \"changes\": {^
+    \"quantum\": \"1\",^
     \"erc20\": {^
      \"withdrawThreshold\": \"10\",^
      \"lifetimeLimit\": \"10\"^
     }^
    }^
   },^
-  \"closingTimestamp\": 1664964291,^
-  \"enactmentTimestamp\": 1665050691^
+  \"closingTimestamp\": 1664982989,^
+  \"enactmentTimestamp\": 1665069389^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
@@ -141,7 +141,7 @@
       tau: 0.0001140771161,
 
       // Risk Aversion Parameter (double as number) 
-      riskAversionParameter: "0.0001",
+      riskAversionParameter: "0.01",
 
       // Risk model parameters for log normal
       params: {
@@ -160,11 +160,11 @@
 
    // Timestamp (Unix time in seconds) when voting closes for this proposal,
    // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-   closingTimestamp: 1664982989,
+   closingTimestamp: 1665313779,
 
    // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
    // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-   enactmentTimestamp: 1665069389,
+   enactmentTimestamp: 1665400179,
   }
  }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
@@ -20,8 +20,8 @@
       // Human-readable name/abbreviation of the quote name (string)
       quoteName: "tEuro",
 
-      // The number of decimal places implied by the settlement data (such as price) emitted by the settlement oracle (int64 as integer)
-      settlementDataDecimals: 5,
+      // The number of decimal places implied by the settlement price emitted by the settlement oracle (int64 as integer)
+      settlementPriceDecimals: 5,
 
       // The oracle spec describing the oracle data of settlement price (object)
       oracleSpecForSettlementPrice: {
@@ -112,8 +112,7 @@
 
      // Optional market metadata, tags
      metadata: [
-      "sector:energy",
-      "sector:food",
+      "sector:tech",
       "source:docs.vega.xyz"
      ],
 
@@ -142,7 +141,7 @@
       tau: 0.0001140771161,
 
       // Risk Aversion Parameter (double as number) 
-      riskAversionParameter: "0.001",
+      riskAversionParameter: "0.0001",
 
       // Risk model parameters for log normal
       params: {
@@ -161,11 +160,11 @@
 
    // Timestamp (Unix time in seconds) when voting closes for this proposal,
    // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-   closingTimestamp: 1666044439,
+   closingTimestamp: 1664964291,
 
    // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
    // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-   enactmentTimestamp: 1666130839,
+   enactmentTimestamp: 1665050691,
   }
  }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
@@ -13,15 +13,15 @@
     // Updated market instrument configuration
     instrument: {
      // Instrument code, human-readable shortcode used to describe the instrument
-     code: "ORANGES.24h",
+     code: "APPLES.22",
 
      // Future
      future: {
       // Human-readable name/abbreviation of the quote name (string)
       quoteName: "tEuro",
 
-      // The number of decimal places implied by the settlement price emitted by the settlement oracle (int64 as integer)
-      settlementPriceDecimals: 5,
+      // The number of decimal places implied by the settlement data (such as price) emitted by the settlement oracle (int64 as integer)
+      settlementDataDecimals: 5,
 
       // The oracle spec describing the oracle data of settlement price (object)
       oracleSpecForSettlementPrice: {
@@ -113,6 +113,7 @@
      // Optional market metadata, tags
      metadata: [
       "sector:tech",
+      "sector:food",
       "source:docs.vega.xyz"
      ],
 
@@ -141,7 +142,7 @@
       tau: 0.0001140771161,
 
       // Risk Aversion Parameter (double as number) 
-      riskAversionParameter: "0.01",
+      riskAversionParameter: "0.0001",
 
       // Risk model parameters for log normal
       params: {
@@ -152,7 +153,7 @@
        r: 0.016,
 
        // Sigma param (double as number) 
-       sigma: 0.5,
+       sigma: 0.8,
       }
      },
     },
@@ -160,11 +161,11 @@
 
    // Timestamp (Unix time in seconds) when voting closes for this proposal,
    // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-   closingTimestamp: 1665313779,
+   closingTimestamp: 1666539201,
 
    // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
    // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-   enactmentTimestamp: 1665400179,
+   enactmentTimestamp: 1666625601,
   }
  }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
@@ -13,7 +13,7 @@
     // Updated market instrument configuration
     instrument: {
      // Instrument code, human-readable shortcode used to describe the instrument
-     code: "APPLES.22",
+     code: "ORANGES.24h",
 
      // Future
      future: {
@@ -152,7 +152,7 @@
        r: 0.016,
 
        // Sigma param (double as number) 
-       sigma: 0.3,
+       sigma: 0.5,
       }
      },
     },
@@ -160,11 +160,11 @@
 
    // Timestamp (Unix time in seconds) when voting closes for this proposal,
    // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-   closingTimestamp: 1664964291,
+   closingTimestamp: 1664982989,
 
    // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
    // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-   enactmentTimestamp: 1665050691,
+   enactmentTimestamp: 1665069389,
   }
  }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
@@ -14,7 +14,7 @@
       "code": "APPLES.22",
       "future": {
        "quoteName": "tEuro",
-       "settlementDataDecimals": 5,
+       "settlementPriceDecimals": 5,
        "oracleSpecForSettlementPrice": {
         "pubKeys": [
          "0xfCEAdAFab14d46e20144F48824d0C09B1a03F2BC"
@@ -60,8 +60,7 @@
       }
      },
      "metadata": [
-      "sector:energy",
-      "sector:food",
+      "sector:tech",
       "source:docs.vega.xyz"
      ],
      "priceMonitoringParameters": {
@@ -75,7 +74,7 @@
      },
      "logNormal": {
       "tau": 0.0001140771161,
-      "riskAversionParameter": 0.001,
+      "riskAversionParameter": 0.0001,
       "params": {
        "mu": 0,
        "r": 0.016,
@@ -84,8 +83,8 @@
      }
     }
    },
-   "closingTimestamp": 1666044439,
-   "enactmentTimestamp": 1666130839
+   "closingTimestamp": 1664964291,
+   "enactmentTimestamp": 1665050691
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
@@ -74,7 +74,7 @@
      },
      "logNormal": {
       "tau": 0.0001140771161,
-      "riskAversionParameter": 0.0001,
+      "riskAversionParameter": 0.01,
       "params": {
        "mu": 0,
        "r": 0.016,
@@ -83,8 +83,8 @@
      }
     }
    },
-   "closingTimestamp": 1664982989,
-   "enactmentTimestamp": 1665069389
+   "closingTimestamp": 1665313779,
+   "enactmentTimestamp": 1665400179
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
@@ -11,10 +11,10 @@
     "marketId": "123",
     "changes": {
      "instrument": {
-      "code": "ORANGES.24h",
+      "code": "APPLES.22",
       "future": {
        "quoteName": "tEuro",
-       "settlementPriceDecimals": 5,
+       "settlementDataDecimals": 5,
        "oracleSpecForSettlementPrice": {
         "pubKeys": [
          "0xfCEAdAFab14d46e20144F48824d0C09B1a03F2BC"
@@ -61,6 +61,7 @@
      },
      "metadata": [
       "sector:tech",
+      "sector:food",
       "source:docs.vega.xyz"
      ],
      "priceMonitoringParameters": {
@@ -74,17 +75,17 @@
      },
      "logNormal": {
       "tau": 0.0001140771161,
-      "riskAversionParameter": 0.01,
+      "riskAversionParameter": 0.0001,
       "params": {
        "mu": 0,
        "r": 0.016,
-       "sigma": 0.5
+       "sigma": 0.8
       }
      }
     }
    },
-   "closingTimestamp": 1665313779,
-   "enactmentTimestamp": 1665400179
+   "closingTimestamp": 1666539201,
+   "enactmentTimestamp": 1666625601
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
@@ -11,7 +11,7 @@
     "marketId": "123",
     "changes": {
      "instrument": {
-      "code": "APPLES.22",
+      "code": "ORANGES.24h",
       "future": {
        "quoteName": "tEuro",
        "settlementPriceDecimals": 5,
@@ -78,13 +78,13 @@
       "params": {
        "mu": 0,
        "r": 0.016,
-       "sigma": 0.3
+       "sigma": 0.5
       }
      }
     }
    },
-   "closingTimestamp": 1664964291,
-   "enactmentTimestamp": 1665050691
+   "closingTimestamp": 1664982989,
+   "enactmentTimestamp": 1665069389
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
@@ -13,7 +13,7 @@
           "code": "APPLES.22",
           "future": {
             "quoteName": "tEuro",
-            "settlementDataDecimals": 5,
+            "settlementPriceDecimals": 5,
             "oracleSpecForSettlementPrice": {
               "pubKeys": [
                 "0xfCEAdAFab14d46e20144F48824d0C09B1a03F2BC"
@@ -59,8 +59,7 @@
           }
         },
         "metadata": [
-          "sector:energy",
-          "sector:food",
+          "sector:tech",
           "source:docs.vega.xyz"
         ],
         "priceMonitoringParameters": {
@@ -74,7 +73,7 @@
         },
         "logNormal": {
           "tau": 0.0001140771161,
-          "riskAversionParameter": 0.001,
+          "riskAversionParameter": 0.0001,
           "params": {
             "mu": 0,
             "r": 0.016,
@@ -83,8 +82,8 @@
         }
       }
     },
-    "closingTimestamp": 1666044439,
-    "enactmentTimestamp": 1666130839
+    "closingTimestamp": 1664964291,
+    "enactmentTimestamp": 1665050691
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
@@ -73,7 +73,7 @@
         },
         "logNormal": {
           "tau": 0.0001140771161,
-          "riskAversionParameter": 0.0001,
+          "riskAversionParameter": 0.01,
           "params": {
             "mu": 0,
             "r": 0.016,
@@ -82,8 +82,8 @@
         }
       }
     },
-    "closingTimestamp": 1664982989,
-    "enactmentTimestamp": 1665069389
+    "closingTimestamp": 1665313779,
+    "enactmentTimestamp": 1665400179
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
@@ -10,7 +10,7 @@
       "marketId": "123",
       "changes": {
         "instrument": {
-          "code": "APPLES.22",
+          "code": "ORANGES.24h",
           "future": {
             "quoteName": "tEuro",
             "settlementPriceDecimals": 5,
@@ -77,13 +77,13 @@
           "params": {
             "mu": 0,
             "r": 0.016,
-            "sigma": 0.3
+            "sigma": 0.5
           }
         }
       }
     },
-    "closingTimestamp": 1664964291,
-    "enactmentTimestamp": 1665050691
+    "closingTimestamp": 1664982989,
+    "enactmentTimestamp": 1665069389
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
@@ -10,10 +10,10 @@
       "marketId": "123",
       "changes": {
         "instrument": {
-          "code": "ORANGES.24h",
+          "code": "APPLES.22",
           "future": {
             "quoteName": "tEuro",
-            "settlementPriceDecimals": 5,
+            "settlementDataDecimals": 5,
             "oracleSpecForSettlementPrice": {
               "pubKeys": [
                 "0xfCEAdAFab14d46e20144F48824d0C09B1a03F2BC"
@@ -60,6 +60,7 @@
         },
         "metadata": [
           "sector:tech",
+          "sector:food",
           "source:docs.vega.xyz"
         ],
         "priceMonitoringParameters": {
@@ -73,17 +74,17 @@
         },
         "logNormal": {
           "tau": 0.0001140771161,
-          "riskAversionParameter": 0.01,
+          "riskAversionParameter": 0.0001,
           "params": {
             "mu": 0,
             "r": 0.016,
-            "sigma": 0.5
+            "sigma": 0.8
           }
         }
       }
     },
-    "closingTimestamp": 1665313779,
-    "enactmentTimestamp": 1665400179
+    "closingTimestamp": 1666539201,
+    "enactmentTimestamp": 1666625601
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
@@ -75,7 +75,7 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
     },^
     \"logNormal\": {^
      \"tau\": 0.0001140771161,^
-     \"riskAversionParameter\": 0.0001,^
+     \"riskAversionParameter\": 0.01,^
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
@@ -84,8 +84,8 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
     }^
    }^
   },^
-  \"closingTimestamp\": 1664982989,^
-  \"enactmentTimestamp\": 1665069389^
+  \"closingTimestamp\": 1665313779,^
+  \"enactmentTimestamp\": 1665400179^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
@@ -15,7 +15,7 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
      \"code\": \"APPLES.22\",^
      \"future\": {^
       \"quoteName\": \"tEuro\",^
-      \"settlementDataDecimals\": 5,^
+      \"settlementPriceDecimals\": 5,^
       \"oracleSpecForSettlementPrice\": {^
        \"pubKeys\": [^
         \"0xfCEAdAFab14d46e20144F48824d0C09B1a03F2BC\"^
@@ -61,8 +61,7 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
      }^
     },^
     \"metadata\": [^
-     \"sector:energy\",^
-     \"sector:food\",^
+     \"sector:tech\",^
      \"source:docs.vega.xyz\"^
     ],^
     \"priceMonitoringParameters\": {^
@@ -76,7 +75,7 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
     },^
     \"logNormal\": {^
      \"tau\": 0.0001140771161,^
-     \"riskAversionParameter\": 0.001,^
+     \"riskAversionParameter\": 0.0001,^
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
@@ -85,8 +84,8 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
     }^
    }^
   },^
-  \"closingTimestamp\": 1666044439,^
-  \"enactmentTimestamp\": 1666130839^
+  \"closingTimestamp\": 1664964291,^
+  \"enactmentTimestamp\": 1665050691^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
@@ -12,7 +12,7 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
    \"marketId\": \"123\",^
    \"changes\": {^
     \"instrument\": {^
-     \"code\": \"APPLES.22\",^
+     \"code\": \"ORANGES.24h\",^
      \"future\": {^
       \"quoteName\": \"tEuro\",^
       \"settlementPriceDecimals\": 5,^
@@ -79,13 +79,13 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
-      \"sigma\": 0.3^
+      \"sigma\": 0.5^
      }^
     }^
    }^
   },^
-  \"closingTimestamp\": 1664964291,^
-  \"enactmentTimestamp\": 1665050691^
+  \"closingTimestamp\": 1664982989,^
+  \"enactmentTimestamp\": 1665069389^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
@@ -12,10 +12,10 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
    \"marketId\": \"123\",^
    \"changes\": {^
     \"instrument\": {^
-     \"code\": \"ORANGES.24h\",^
+     \"code\": \"APPLES.22\",^
      \"future\": {^
       \"quoteName\": \"tEuro\",^
-      \"settlementPriceDecimals\": 5,^
+      \"settlementDataDecimals\": 5,^
       \"oracleSpecForSettlementPrice\": {^
        \"pubKeys\": [^
         \"0xfCEAdAFab14d46e20144F48824d0C09B1a03F2BC\"^
@@ -62,6 +62,7 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
     },^
     \"metadata\": [^
      \"sector:tech\",^
+     \"sector:food\",^
      \"source:docs.vega.xyz\"^
     ],^
     \"priceMonitoringParameters\": {^
@@ -75,17 +76,17 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
     },^
     \"logNormal\": {^
      \"tau\": 0.0001140771161,^
-     \"riskAversionParameter\": 0.01,^
+     \"riskAversionParameter\": 0.0001,^
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
-      \"sigma\": 0.5^
+      \"sigma\": 0.8^
      }^
     }^
    }^
   },^
-  \"closingTimestamp\": 1665313779,^
-  \"enactmentTimestamp\": 1665400179^
+  \"closingTimestamp\": 1666539201,^
+  \"enactmentTimestamp\": 1666625601^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
@@ -2,14 +2,14 @@
   ```javascript
 {
  rationale: {
-  title: "Update governance.proposal.asset.requiredMajority",
-  description: "Proposal to update governance.proposal.asset.requiredMajority to 300}"
+  title: "Update market.fee.factors.infrastructureFee",
+  description: "Proposal to update market.fee.factors.infrastructureFee to 300}"
  },
  terms: {
   updateNetworkParameter: {
    changes: {
     // The unique key (string) 
-    key: "governance.proposal.asset.requiredMajority",
+    key: "market.fee.factors.infrastructureFee",
 
     // The value for the network parameter (string) 
     value: "300"
@@ -18,11 +18,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1665313779,
+  closingTimestamp: 1666539201,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665400179,
+  enactmentTimestamp: 1666625601,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
@@ -2,14 +2,14 @@
   ```javascript
 {
  rationale: {
-  title: "Update governance.proposal.asset.requiredMajority",
-  description: "Proposal to update governance.proposal.asset.requiredMajority to 300}"
+  title: "Update market.fee.factors.infrastructureFee",
+  description: "Proposal to update market.fee.factors.infrastructureFee to 300}"
  },
  terms: {
   updateNetworkParameter: {
    changes: {
     // The unique key (string) 
-    key: "governance.proposal.asset.requiredMajority",
+    key: "market.fee.factors.infrastructureFee",
 
     // The value for the network parameter (string) 
     value: "300"
@@ -18,11 +18,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1666044439,
+  closingTimestamp: 1664964291,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1666130839,
+  enactmentTimestamp: 1665050691,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
@@ -2,14 +2,14 @@
   ```javascript
 {
  rationale: {
-  title: "Update market.fee.factors.infrastructureFee",
-  description: "Proposal to update market.fee.factors.infrastructureFee to 300}"
+  title: "Update governance.proposal.asset.requiredMajority",
+  description: "Proposal to update governance.proposal.asset.requiredMajority to 300}"
  },
  terms: {
   updateNetworkParameter: {
    changes: {
     // The unique key (string) 
-    key: "market.fee.factors.infrastructureFee",
+    key: "governance.proposal.asset.requiredMajority",
 
     // The value for the network parameter (string) 
     value: "300"
@@ -18,11 +18,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1664964291,
+  closingTimestamp: 1664982989,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665050691,
+  enactmentTimestamp: 1665069389,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
@@ -18,11 +18,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1664982989,
+  closingTimestamp: 1665313779,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1665069389,
+  enactmentTimestamp: 1665400179,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
@@ -3,18 +3,18 @@
 ./vegawallet command send --wallet your_walletname --pubkey your_public_key --network fairground '{
  "proposalSubmission": {
   "rationale": {
-   "title": "Update governance.proposal.asset.requiredMajority",
-   "description": "Proposal to update governance.proposal.asset.requiredMajority to 300}"
+   "title": "Update market.fee.factors.infrastructureFee",
+   "description": "Proposal to update market.fee.factors.infrastructureFee to 300}"
   },
   "terms": {
    "updateNetworkParameter": {
     "changes": {
-     "key": "governance.proposal.asset.requiredMajority",
+     "key": "market.fee.factors.infrastructureFee",
      "value": "300"
     }
    },
-   "closingTimestamp": 1666044439,
-   "enactmentTimestamp": 1666130839
+   "closingTimestamp": 1664964291,
+   "enactmentTimestamp": 1665050691
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
@@ -13,8 +13,8 @@
      "value": "300"
     }
    },
-   "closingTimestamp": 1664982989,
-   "enactmentTimestamp": 1665069389
+   "closingTimestamp": 1665313779,
+   "enactmentTimestamp": 1665400179
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
@@ -3,18 +3,18 @@
 ./vegawallet command send --wallet your_walletname --pubkey your_public_key --network fairground '{
  "proposalSubmission": {
   "rationale": {
-   "title": "Update market.fee.factors.infrastructureFee",
-   "description": "Proposal to update market.fee.factors.infrastructureFee to 300}"
+   "title": "Update governance.proposal.asset.requiredMajority",
+   "description": "Proposal to update governance.proposal.asset.requiredMajority to 300}"
   },
   "terms": {
    "updateNetworkParameter": {
     "changes": {
-     "key": "market.fee.factors.infrastructureFee",
+     "key": "governance.proposal.asset.requiredMajority",
      "value": "300"
     }
    },
-   "closingTimestamp": 1664964291,
-   "enactmentTimestamp": 1665050691
+   "closingTimestamp": 1664982989,
+   "enactmentTimestamp": 1665069389
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
@@ -3,18 +3,18 @@
 ./vegawallet command send --wallet your_walletname --pubkey your_public_key --network fairground '{
  "proposalSubmission": {
   "rationale": {
-   "title": "Update governance.proposal.asset.requiredMajority",
-   "description": "Proposal to update governance.proposal.asset.requiredMajority to 300}"
+   "title": "Update market.fee.factors.infrastructureFee",
+   "description": "Proposal to update market.fee.factors.infrastructureFee to 300}"
   },
   "terms": {
    "updateNetworkParameter": {
     "changes": {
-     "key": "governance.proposal.asset.requiredMajority",
+     "key": "market.fee.factors.infrastructureFee",
      "value": "300"
     }
    },
-   "closingTimestamp": 1665313779,
-   "enactmentTimestamp": 1665400179
+   "closingTimestamp": 1666539201,
+   "enactmentTimestamp": 1666625601
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
@@ -2,18 +2,18 @@
   ```json
 {
   "rationale": {
-    "title": "Update governance.proposal.asset.requiredMajority",
-    "description": "Proposal to update governance.proposal.asset.requiredMajority to 300}"
+    "title": "Update market.fee.factors.infrastructureFee",
+    "description": "Proposal to update market.fee.factors.infrastructureFee to 300}"
   },
   "terms": {
     "updateNetworkParameter": {
       "changes": {
-        "key": "governance.proposal.asset.requiredMajority",
+        "key": "market.fee.factors.infrastructureFee",
         "value": "300"
       }
     },
-    "closingTimestamp": 1666044439,
-    "enactmentTimestamp": 1666130839
+    "closingTimestamp": 1664964291,
+    "enactmentTimestamp": 1665050691
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
@@ -12,8 +12,8 @@
         "value": "300"
       }
     },
-    "closingTimestamp": 1664982989,
-    "enactmentTimestamp": 1665069389
+    "closingTimestamp": 1665313779,
+    "enactmentTimestamp": 1665400179
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
@@ -2,18 +2,18 @@
   ```json
 {
   "rationale": {
-    "title": "Update market.fee.factors.infrastructureFee",
-    "description": "Proposal to update market.fee.factors.infrastructureFee to 300}"
+    "title": "Update governance.proposal.asset.requiredMajority",
+    "description": "Proposal to update governance.proposal.asset.requiredMajority to 300}"
   },
   "terms": {
     "updateNetworkParameter": {
       "changes": {
-        "key": "market.fee.factors.infrastructureFee",
+        "key": "governance.proposal.asset.requiredMajority",
         "value": "300"
       }
     },
-    "closingTimestamp": 1664964291,
-    "enactmentTimestamp": 1665050691
+    "closingTimestamp": 1664982989,
+    "enactmentTimestamp": 1665069389
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
@@ -2,18 +2,18 @@
   ```json
 {
   "rationale": {
-    "title": "Update governance.proposal.asset.requiredMajority",
-    "description": "Proposal to update governance.proposal.asset.requiredMajority to 300}"
+    "title": "Update market.fee.factors.infrastructureFee",
+    "description": "Proposal to update market.fee.factors.infrastructureFee to 300}"
   },
   "terms": {
     "updateNetworkParameter": {
       "changes": {
-        "key": "governance.proposal.asset.requiredMajority",
+        "key": "market.fee.factors.infrastructureFee",
         "value": "300"
       }
     },
-    "closingTimestamp": 1665313779,
-    "enactmentTimestamp": 1665400179
+    "closingTimestamp": 1666539201,
+    "enactmentTimestamp": 1666625601
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
@@ -14,8 +14,8 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
     \"value\": \"300\"^
    }^
   },^
-  \"closingTimestamp\": 1664982989,^
-  \"enactmentTimestamp\": 1665069389^
+  \"closingTimestamp\": 1665313779,^
+  \"enactmentTimestamp\": 1665400179^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
@@ -4,18 +4,18 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
 "{^
 \"proposalSubmission\": {^
  \"rationale\": {^
-  \"title\": \"Update governance.proposal.asset.requiredMajority\",^
-  \"description\": \"Proposal to update governance.proposal.asset.requiredMajority to 300}\"^
+  \"title\": \"Update market.fee.factors.infrastructureFee\",^
+  \"description\": \"Proposal to update market.fee.factors.infrastructureFee to 300}\"^
  },^
  \"terms\": {^
   \"updateNetworkParameter\": {^
    \"changes\": {^
-    \"key\": \"governance.proposal.asset.requiredMajority\",^
+    \"key\": \"market.fee.factors.infrastructureFee\",^
     \"value\": \"300\"^
    }^
   },^
-  \"closingTimestamp\": 1666044439,^
-  \"enactmentTimestamp\": 1666130839^
+  \"closingTimestamp\": 1664964291,^
+  \"enactmentTimestamp\": 1665050691^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
@@ -4,18 +4,18 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
 "{^
 \"proposalSubmission\": {^
  \"rationale\": {^
-  \"title\": \"Update market.fee.factors.infrastructureFee\",^
-  \"description\": \"Proposal to update market.fee.factors.infrastructureFee to 300}\"^
+  \"title\": \"Update governance.proposal.asset.requiredMajority\",^
+  \"description\": \"Proposal to update governance.proposal.asset.requiredMajority to 300}\"^
  },^
  \"terms\": {^
   \"updateNetworkParameter\": {^
    \"changes\": {^
-    \"key\": \"market.fee.factors.infrastructureFee\",^
+    \"key\": \"governance.proposal.asset.requiredMajority\",^
     \"value\": \"300\"^
    }^
   },^
-  \"closingTimestamp\": 1664964291,^
-  \"enactmentTimestamp\": 1665050691^
+  \"closingTimestamp\": 1664982989,^
+  \"enactmentTimestamp\": 1665069389^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
@@ -4,18 +4,18 @@ vegawallet.exe command send --wallet your_walletname --pubkey your_public_key --
 "{^
 \"proposalSubmission\": {^
  \"rationale\": {^
-  \"title\": \"Update governance.proposal.asset.requiredMajority\",^
-  \"description\": \"Proposal to update governance.proposal.asset.requiredMajority to 300}\"^
+  \"title\": \"Update market.fee.factors.infrastructureFee\",^
+  \"description\": \"Proposal to update market.fee.factors.infrastructureFee to 300}\"^
  },^
  \"terms\": {^
   \"updateNetworkParameter\": {^
    \"changes\": {^
-    \"key\": \"governance.proposal.asset.requiredMajority\",^
+    \"key\": \"market.fee.factors.infrastructureFee\",^
     \"value\": \"300\"^
    }^
   },^
-  \"closingTimestamp\": 1665313779,^
-  \"enactmentTimestamp\": 1665400179^
+  \"closingTimestamp\": 1666539201,^
+  \"enactmentTimestamp\": 1666625601^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/new-asset-proposal.md
+++ b/docs/tutorials/proposals/new-asset-proposal.md
@@ -27,7 +27,7 @@ You will need:
 * A connected [Vega wallet](/docs/tools/vega-wallet/index.md), with your wallet name and public key to hand
 * A minimum of whichever is larger, associated with that public key: <NetworkParameter frontMatter={frontMatter} param="governance.proposal.asset.minProposerBalance" hideName={true} suffix="tokens"/> or <NetworkParameter frontMatter={frontMatter} param="spam.protection.proposal.min.tokens" hideName={true}  formatter="governanceToken" suffix="tokens"/>
 * Familiarity with [governance on Vega](../../concepts/vega-protocol.md#governance), particularly [assets at a protocol level](../../concepts/vega-protocol#assettoken-management)
-- After a new asset vote passes, the change has to be submitted to the [asset bridge](../../api/bridge/interfaces/IERC20_Bridge_Logic) on Ethereum. Until it has been submitted, no one can start depositing that asset.
+- After a new asset vote passes, the change has to be submitted to the [asset bridge](../../concepts/vega-protocol#assettoken-management) on Ethereum. Until it has been submitted, no one can start depositing that asset.
 
 ## Overview
 Vega currently supports adding [ERC-20 assets ↗](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/#top). ERC-20 assets that pass a governance vote can be enabled [via the Vega bridge](../../api/bridge/index.md) - which is to say that they are deposited from and withdrawn to Ethereum. More token standards and chains are on the roadmap.

--- a/docs/tutorials/proposals/update-asset-bridge.md
+++ b/docs/tutorials/proposals/update-asset-bridge.md
@@ -25,5 +25,4 @@ You will need:
 
 ## Overview
 
-When the validators have created a multisig bundle, it is available for anyone to submit to the bridge to complete the update. 
-
+When the validators have created a multisig bundle, it is available for anyone to submit to the bridge to complete the up

--- a/docs/tutorials/proposals/update-asset-bridge.md
+++ b/docs/tutorials/proposals/update-asset-bridge.md
@@ -12,6 +12,9 @@ tags:
   - asset
 ---
 
+import NetworkParameter from '@site/src/components/NetworkParameter';
+import EthAddresses from '@site/src/components/EthAddresses';
+
 # Update the asset bridge
 
 Vega supports ERC20 assets, which can be deposited to and withdrawn from Vega through the asset bridge. When a governance proposal votes to add support for a new asset, or make changes to an existing asset, the bridge must also be updated. When a relevant proposal is voted in, Vega validators automatically create a multisig bundle - a collection of signatures indicating their approval of the update - but that bundle must be submitted to the bridge before the change takes place. This guide walks through that process.
@@ -22,11 +25,31 @@ You will need:
 
 - An Ethereum wallet
 - Familiarity with [governance on Vega](../../concepts/vega-protocol.md#governance), particularly [assets at a protocol level](../../concepts/vega-protocol#assettoken-management), as well as how the [asset bridge](../../concepts/vega-protocol#assettoken-management) works on Ethereum.
+- An asset proposal ([new asset](./new-asset-proposal.md) or an [asset update(./update-asset-proposal.md) that has passed a vote)
 
 ## Overview
 
-When the validators have created a multisig bundle, it is available for anyone to submit to the bridge to complete the up
+When the validators have created a multisig bundle, it is available for anyone to submit to the bridge to complete the update. This 
 
 ## 1. Get the ID of the new/changing asset
+
 ## 2. Fetch the signature bundle for the change
+
 ## 3. Submit the update to Ethereum
+
+Now that you have the signature bundle, it needs to be submitted to the smart contract to enact the changes:
+
+<EthAddresses frontMatter={frontMatter} show={["erc20Bridge"]} />
+
+:::tip Etherscan
+You can use Etherscan's [Write to contract](https://www.web3.university/article/how-to-interact-with-smart-contracts) feature to submit the bundle, or create the transaction using your own wallet.
+:::
+
+* For listing an asset (with the signature bundle from a New Asset proposal), the correct method is [`list_asset`](../../api/bridge/contracts/ERC20_Bridge_Logic#list_asset)
+* For updating an asset, the correct method is  [`set_asset_limits`](../../api/bridge/contracts/ERC20_Bridge_Logic#set_asset_limits)
+
+In both cases, you will need to submit the values that were voted for, and the signature bundle you obtained in step 2. These must match the values that were voted on, or the update will fail. When the update transaction is finalised on Ethereum, the changes go in to effect. This means that users will be able to deposit the new asset, or the updated asset properties will be reflected on the contract.
+
+:::note Verifying the bridge address
+The bridge address is set by a network parameter. so to verify that this bridge address is correct you can check <NetworkParameter frontMatter={frontMatter} param="blockchains.ethereumConfig" hideValue={true} />
+:::

--- a/docs/tutorials/proposals/update-asset-bridge.md
+++ b/docs/tutorials/proposals/update-asset-bridge.md
@@ -26,3 +26,7 @@ You will need:
 ## Overview
 
 When the validators have created a multisig bundle, it is available for anyone to submit to the bridge to complete the up
+
+## 1. Get the ID of the new/changing asset
+## 2. Fetch the signature bundle for the change
+## 3. Submit the update to Ethereum

--- a/docs/tutorials/proposals/update-asset-bridge.md
+++ b/docs/tutorials/proposals/update-asset-bridge.md
@@ -3,6 +3,7 @@ sidebar_position: 4
 title: Asset bridge updates
 hide_title: false
 vega_network: TESTNET
+ethereum_network: Ropsten
 keywords:
   - proposal
   - governance

--- a/docs/tutorials/proposals/update-asset-bridge.md
+++ b/docs/tutorials/proposals/update-asset-bridge.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-title: Asset bridge updates
+title: Update asset bridge
 hide_title: false
 vega_network: TESTNET
 ethereum_network: Ropsten
@@ -17,22 +17,23 @@ import NetworkParameter from '@site/src/components/NetworkParameter';
 import EthAddresses from '@site/src/components/EthAddresses';
 
 # Update the asset bridge
+Vega supports adding ERC-20 assets, which can be deposited to and withdrawn from Vega through the ERC-20 asset bridge. 
 
-Vega supports ERC20 assets, which can be deposited to and withdrawn from Vega through the asset bridge. When a governance proposal votes to add support for a new asset, or make changes to an existing asset, the bridge must also be updated. When a relevant proposal is voted in, Vega validators automatically create a multisig bundle - a collection of signatures indicating their approval of the update - but that bundle must be submitted to the bridge before the change takes place. This guide walks through that process.
+When a governance proposal to add support for a new asset, or make changes to an existing asset is enacted, the bridge must also be updated.
+
+Vega validators automatically create a multisig bundle - a collection of signatures indicating their approval of the update. That bundle must be submitted to the bridge before the change takes place. This guide walks through that process.
 
 ## Requirements
-
 You will need:
-
-- An Ethereum wallet
-- Familiarity with [governance on Vega](../../concepts/vega-protocol.md#governance), particularly [assets at a protocol level](../../concepts/vega-protocol#assettoken-management), as well as how the [asset bridge](../../concepts/vega-protocol#assettoken-management) works on Ethereum.
+* An Ethereum wallet
+* Familiarity with [governance on Vega](../../concepts/vega-protocol.md#governance), particularly [assets at a protocol level](../../concepts/vega-protocol#assettoken-management), as well as how the [asset bridge](../../concepts/vega-protocol#assettoken-management) works on Ethereum.
 
 As an alternative to making the transaction yourself, Etherscan provides a simple interface that can be used to submit updates to the bridge. You can access it by visiting the relevant contract page, under 'Contract' > 'Write contract'.
 
 ## Listing an asset
 When the validators have created a multisig bundle, it is available for anyone to submit to the bridge to complete the update. 
 
-### 1. Propose your change
+### 1. Confirm asset proposal has passed
 First, you must have the change approved by the network through governance, using a ([new asset proposal](./new-asset-proposal.md)
 
 ### 2. Get the ID of the new asset
@@ -42,11 +43,10 @@ The asset for a new ID will be the same as the ID of the proposal that created i
 * REST: [List asset bundles](../../api/rest/data-v2/trading-data-service-get-erc-20-list-asset-bundle)
 * GRPC: [List asset bundles](../../grpc/data-node/api/v2/trading_data.proto#geterc20listassetbundlerequest)
 
-Use one of the API calls to fetch the signature bundle from the network. This string contains the approval of the validator nodes of the network for the changes, and is checked by the bridge smart contract. Take a note of the signature bundle and the `nonce`, both of which we will submit to the contract.
+Use one of the API calls to fetch the signature bundle from the network. This string contains the approval of the validator nodes of the network for the changes, and is checked by the bridge smart contract. Take a note of the signature bundle and the `nonce`, both of which you will submit to the contract.
 
 ### 4. Submit the update to Ethereum
-
-Now that you have all the details required, they need to be submitted to the smart contract to enact the changes:
+Once you have all the details required, they need to be submitted to the smart contract to enact the changes:
 
 <EthAddresses frontMatter={frontMatter} show={["erc20Bridge"]} />
 
@@ -55,10 +55,9 @@ Now that you have all the details required, they need to be submitted to the sma
 These values you submit here must match the values that were voted on, or the transaction will fail. When the update transaction is finalised on Ethereum, the changes go in to effect. This means that users will be able to deposit the new asset.
 
 ## Updating an asset
-
 Most properties on an asset cannot be changed at creation. There are two limits in place that can be changed, and this wallet assumes that you are changine either the `lifetimeLimit` or `threshold`.
 
-### 1. Propose your change
+### 1. Confirm asset proposal has passed
 First, you must have the change approved by the network through governance, using an ([update asset proposal](./update-asset-proposal.md). Unlike New Asset proposals, the asset ID doesn't change as a result, so you already have the asset ID you need in step 3.
 
 ### 2. Fetch the signature bundle for the change
@@ -68,7 +67,6 @@ First, you must have the change approved by the network through governance, usin
 Use one of the API calls to fetch the signature bundle from the network. This string contains the approval of the validator nodes of the network for the changes, and is checked by the bridge smart contract. Take a note of the signature bundle and the `nonce`, both of which we will submit to the contract.
 
 ### 3. Submit the update to Ethereum
-
 Now that you have all the details required, they need to be submitted to the smart contract to enact the changes:
 
 <EthAddresses frontMatter={frontMatter} show={["erc20Bridge"]} />

--- a/docs/tutorials/proposals/update-asset-bridge.md
+++ b/docs/tutorials/proposals/update-asset-bridge.md
@@ -50,8 +50,7 @@ Now that you have all the details required, they need to be submitted to the sma
 
 <EthAddresses frontMatter={frontMatter} show={["erc20Bridge"]} />
 
-* For listing an asset (with the signature bundle from a New Asset proposal), the correct method is [`list_asset`](../../api/bridge/contracts/ERC20_Bridge_Logic#list_asset)
-* For updating an asset, the correct method is  [`set_asset_limits`](../../api/bridge/contracts/ERC20_Bridge_Logic#set_asset_limits)
+* For listing an asset the correct method is [`list_asset`](../../api/bridge/contracts/ERC20_Bridge_Logic#list_asset)
 
 These values you submit here must match the values that were voted on, or the transaction will fail. When the update transaction is finalised on Ethereum, the changes go in to effect. This means that users will be able to deposit the new asset.
 

--- a/docs/tutorials/proposals/update-asset-bridge.md
+++ b/docs/tutorials/proposals/update-asset-bridge.md
@@ -26,31 +26,54 @@ You will need:
 
 - An Ethereum wallet
 - Familiarity with [governance on Vega](../../concepts/vega-protocol.md#governance), particularly [assets at a protocol level](../../concepts/vega-protocol#assettoken-management), as well as how the [asset bridge](../../concepts/vega-protocol#assettoken-management) works on Ethereum.
-- An asset proposal ([new asset](./new-asset-proposal.md) or an [asset update(./update-asset-proposal.md) that has passed a vote)
 
-## Overview
+As an alternative to making the transaction yourself, Etherscan provides a simple interface that can be used to submit updates to the bridge. You can access it by visiting the relevant contract page, under 'Contract' > 'Write contract'.
 
-When the validators have created a multisig bundle, it is available for anyone to submit to the bridge to complete the update. This 
+## Listing an asset
+When the validators have created a multisig bundle, it is available for anyone to submit to the bridge to complete the update. 
 
-## 1. Get the ID of the new/changing asset
+### 1. Propose your change
+First, you must have the change approved by the network through governance, using a ([new asset proposal](./new-asset-proposal.md)
 
-## 2. Fetch the signature bundle for the change
+### 2. Get the ID of the new asset
+The asset for a new ID will be the same as the ID of the proposal that created it.
 
-## 3. Submit the update to Ethereum
+### 3. Fetch the signature bundle for the change
+* REST: [List asset bundles](../../api/rest/data-v2/trading-data-service-get-erc-20-list-asset-bundle)
+* GRPC: [List asset bundles](../../grpc/data-node/api/v2/trading_data.proto#geterc20listassetbundlerequest)
 
-Now that you have the signature bundle, it needs to be submitted to the smart contract to enact the changes:
+Use one of the API calls to fetch the signature bundle from the network. This string contains the approval of the validator nodes of the network for the changes, and is checked by the bridge smart contract. Take a note of the signature bundle and the `nonce`, both of which we will submit to the contract.
+
+### 4. Submit the update to Ethereum
+
+Now that you have all the details required, they need to be submitted to the smart contract to enact the changes:
 
 <EthAddresses frontMatter={frontMatter} show={["erc20Bridge"]} />
-
-:::tip Etherscan
-You can use Etherscan's [Write to contract](https://www.web3.university/article/how-to-interact-with-smart-contracts) feature to submit the bundle, or create the transaction using your own wallet.
-:::
 
 * For listing an asset (with the signature bundle from a New Asset proposal), the correct method is [`list_asset`](../../api/bridge/contracts/ERC20_Bridge_Logic#list_asset)
 * For updating an asset, the correct method is  [`set_asset_limits`](../../api/bridge/contracts/ERC20_Bridge_Logic#set_asset_limits)
 
-In both cases, you will need to submit the values that were voted for, and the signature bundle you obtained in step 2. These must match the values that were voted on, or the update will fail. When the update transaction is finalised on Ethereum, the changes go in to effect. This means that users will be able to deposit the new asset, or the updated asset properties will be reflected on the contract.
+These values you submit here must match the values that were voted on, or the transaction will fail. When the update transaction is finalised on Ethereum, the changes go in to effect. This means that users will be able to deposit the new asset.
 
-:::note Verifying the bridge address
-The bridge address is set by a network parameter. so to verify that this bridge address is correct you can check <NetworkParameter frontMatter={frontMatter} param="blockchains.ethereumConfig" hideValue={true} />
-:::
+## Updating an asset
+
+Most properties on an asset cannot be changed at creation. There are two limits in place that can be changed, and this wallet assumes that you are changine either the `lifetimeLimit` or `threshold`.
+
+### 1. Propose your change
+First, you must have the change approved by the network through governance, using an ([update asset proposal](./update-asset-proposal.md). Unlike New Asset proposals, the asset ID doesn't change as a result, so you already have the asset ID you need in step 3.
+
+### 2. Fetch the signature bundle for the change
+* GRPC: [Set asset limit bundle](../..//grpc/data-node/api/v2/trading_data.proto#geterc20setassetlimitsbundlerequest)
+* REST: [Set asset limit bundle](../../api/rest/data-v2/trading-data-service-get-erc-20-set-asset-limits-bundle)
+
+Use one of the API calls to fetch the signature bundle from the network. This string contains the approval of the validator nodes of the network for the changes, and is checked by the bridge smart contract. Take a note of the signature bundle and the `nonce`, both of which we will submit to the contract.
+
+### 3. Submit the update to Ethereum
+
+Now that you have all the details required, they need to be submitted to the smart contract to enact the changes:
+
+<EthAddresses frontMatter={frontMatter} show={["erc20Bridge"]} />
+
+The correct method for updating the asset is  [`set_asset_limits`](../../api/bridge/contracts/ERC20_Bridge_Logic#set_asset_limits)
+
+These must match the values that were voted on, or the update will fail. When the update transaction is finalised on Ethereum, the changes go in to effect. This means that the new limits will be reflected on the contract.

--- a/docs/tutorials/proposals/update-asset-bridge.md
+++ b/docs/tutorials/proposals/update-asset-bridge.md
@@ -64,7 +64,7 @@ First, you must have the change approved by the network through governance, usin
 
 ### 2. Fetch the signature bundle for the change
 * REST: [Set asset limit bundle](../../api/rest/data-v2/trading-data-service-get-erc-20-set-asset-limits-bundle)
-* GRPC: [Set asset limit bundle](../..//grpc/data-node/api/v2/trading_data.proto#geterc20setassetlimitsbundlerequest)
+* GRPC: [Set asset limit bundle](../../grpc/data-node/api/v2/trading_data.proto#geterc20setassetlimitsbundlerequest)
 
 Use one of the API calls to fetch the signature bundle from the network. This string contains the approval of the validator nodes of the network for the changes, and is checked by the bridge smart contract. Take a note of the signature bundle and the `nonce`, both of which we will submit to the contract.
 

--- a/docs/tutorials/proposals/update-asset-bridge.md
+++ b/docs/tutorials/proposals/update-asset-bridge.md
@@ -1,0 +1,29 @@
+---
+sidebar_position: 4
+title: Asset bridge updates
+hide_title: false
+vega_network: TESTNET
+keywords:
+  - proposal
+  - governance
+  - updateAsset
+tags:
+  - governance
+  - asset
+---
+
+# Update the asset bridge
+
+Vega supports ERC20 assets, which can be deposited to and withdrawn from Vega through the asset bridge. When a governance proposal votes to add support for a new asset, or make changes to an existing asset, the bridge must also be updated. When a relevant proposal is voted in, Vega validators automatically create a multisig bundle - a collection of signatures indicating their approval of the update - but that bundle must be submitted to the bridge before the change takes place. This guide walks through that process.
+
+## Requirements
+
+You will need:
+
+- An Ethereum wallet
+- Familiarity with [governance on Vega](../../concepts/vega-protocol.md#governance), particularly [assets at a protocol level](../../concepts/vega-protocol#assettoken-management), as well as how the [asset bridge](../../concepts/vega-protocol#assettoken-management) works on Ethereum.
+
+## Overview
+
+When the validators have created a multisig bundle, it is available for anyone to submit to the bridge to complete the update. 
+

--- a/docs/tutorials/proposals/update-asset-bridge.md
+++ b/docs/tutorials/proposals/update-asset-bridge.md
@@ -63,8 +63,8 @@ Most properties on an asset cannot be changed at creation. There are two limits 
 First, you must have the change approved by the network through governance, using an ([update asset proposal](./update-asset-proposal.md). Unlike New Asset proposals, the asset ID doesn't change as a result, so you already have the asset ID you need in step 3.
 
 ### 2. Fetch the signature bundle for the change
-* GRPC: [Set asset limit bundle](../..//grpc/data-node/api/v2/trading_data.proto#geterc20setassetlimitsbundlerequest)
 * REST: [Set asset limit bundle](../../api/rest/data-v2/trading-data-service-get-erc-20-set-asset-limits-bundle)
+* GRPC: [Set asset limit bundle](../..//grpc/data-node/api/v2/trading_data.proto#geterc20setassetlimitsbundlerequest)
 
 Use one of the API calls to fetch the signature bundle from the network. This string contains the approval of the validator nodes of the network for the changes, and is checked by the bridge smart contract. Take a note of the signature bundle and the `nonce`, both of which we will submit to the contract.
 

--- a/docs/tutorials/proposals/update-asset-proposal.md
+++ b/docs/tutorials/proposals/update-asset-proposal.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-title: Propose asset update
+title: Update an asset
 hide_title: false
 vega_network: TESTNET
 keywords:
@@ -24,9 +24,7 @@ import TabItem from '@theme/TabItem';
 
 # Propose an update to an asset
 
-Some of the properties of an asset can be changed through governance. Those fields are: withdrawal and deposit limits, and the asset's quantum.
-
-The underlying contract, asset name and symbol cannot be changed.
+Some of the properties on an asset can be changed through governance. Important fields such as the underlying contract, name and symbol cannot be changed.
 
 ## Requirements
 
@@ -35,7 +33,6 @@ You will need:
 - A connected [Vega wallet](/docs/tools/vega-wallet/index.md), with your wallet name and public key to hand
 - A minimum of whichever is larger, associated with that public key: <NetworkParameter frontMatter={frontMatter} param="governance.proposal.asset.minProposerBalance" hideName={true} suffix="tokens"/> or <NetworkParameter frontMatter={frontMatter} param="spam.protection.proposal.min.tokens" hideName={true}  formatter="governanceToken" suffix="tokens"/>
 - Familiarity with [governance on Vega](../../concepts/vega-protocol.md#governance), particularly [assets at a protocol level](../../concepts/vega-protocol#assettoken-management)
-- After an asset update vote passes, the change has to be submitted to the [asset bridge](../../api/bridge/interfaces/IERC20_Bridge_Logic) on Ethereum.
 
 ## Overview
 
@@ -63,7 +60,7 @@ In the tabs below you'll see an annotated example, which describes what each fie
 
 ## Voting and enactment
 
-All proposals are voted on by the community. To vote, community members need, at a minimum, the larger of <NetworkParameter frontMatter={frontMatter} param="governance.proposal.asset.minVoterBalance" suffix="tokens" hideName={true} formatter="governanceToken" /> or <NetworkParameter frontMatter={frontMatter} formatter="governanceToken" param="spam.protection.voting.min.tokens" suffix="tokens" hideName={true} /> associated with their Vega key.
+All proposals are voted on by the community. To vote, community members need, at a minimum, the larger of <NetworkParameter frontMatter={frontMatter} param="governance.proposal.asset.minVoterBalance" suffix="tokens" hideName={true} /> or <NetworkParameter frontMatter={frontMatter} param="spam.protection.voting.min.tokens" suffix="tokens" hideName={true} /> associated with their Vega key.
 
 Your proposal will need [participation](../../concepts/vega-protocol#how-the-outcome-is-calculated) of <NetworkParameter frontMatter={frontMatter} param="governance.proposal.asset.requiredParticipation" formatter="percent" hideName={true} /> and a majority of <NetworkParameter frontMatter={frontMatter} param="governance.proposal.asset.requiredMajority" formatter="percent" hideName={true} />, so having community support is essential. If successful, the proposal will be enacted at the time you specify in the `enactmentTimestamp` field.
 

--- a/docs/tutorials/proposals/update-asset-proposal.md
+++ b/docs/tutorials/proposals/update-asset-proposal.md
@@ -60,7 +60,7 @@ In the tabs below you'll see an annotated example, which describes what each fie
 
 ## Voting and enactment
 
-All proposals are voted on by the community. To vote, community members need, at a minimum, the larger of <NetworkParameter frontMatter={frontMatter} param="governance.proposal.asset.minVoterBalance" suffix="tokens" hideName={true} /> or <NetworkParameter frontMatter={frontMatter} param="spam.protection.voting.min.tokens" suffix="tokens" hideName={true} /> associated with their Vega key.
+All proposals are voted on by the community. To vote, community members need, at a minimum, the larger of <NetworkParameter frontMatter={frontMatter} param="governance.proposal.asset.minVoterBalance" suffix="tokens" hideName={true} formatter="governanceToken" /> or <NetworkParameter frontMatter={frontMatter} formatter="governanceToken" param="spam.protection.voting.min.tokens" suffix="tokens" hideName={true} /> associated with their Vega key.
 
 Your proposal will need [participation](../../concepts/vega-protocol#how-the-outcome-is-calculated) of <NetworkParameter frontMatter={frontMatter} param="governance.proposal.asset.requiredParticipation" formatter="percent" hideName={true} /> and a majority of <NetworkParameter frontMatter={frontMatter} param="governance.proposal.asset.requiredMajority" formatter="percent" hideName={true} />, so having community support is essential. If successful, the proposal will be enacted at the time you specify in the `enactmentTimestamp` field.
 

--- a/docs/tutorials/proposals/update-asset-proposal.md
+++ b/docs/tutorials/proposals/update-asset-proposal.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-title: Propose asset update
+title: Propose updates to an asset
 hide_title: false
 vega_network: TESTNET
 keywords:

--- a/docs/tutorials/proposals/update-asset-proposal.md
+++ b/docs/tutorials/proposals/update-asset-proposal.md
@@ -35,6 +35,7 @@ You will need:
 - A connected [Vega wallet](/docs/tools/vega-wallet/index.md), with your wallet name and public key to hand
 - A minimum of whichever is larger, associated with that public key: <NetworkParameter frontMatter={frontMatter} param="governance.proposal.asset.minProposerBalance" hideName={true} suffix="tokens"/> or <NetworkParameter frontMatter={frontMatter} param="spam.protection.proposal.min.tokens" hideName={true}  formatter="governanceToken" suffix="tokens"/>
 - Familiarity with [governance on Vega](../../concepts/vega-protocol.md#governance), particularly [assets at a protocol level](../../concepts/vega-protocol#assettoken-management)
+- After an asset update vote passes, the change has to be submitted to the [asset bridge](../../concepts/vega-protocol#assettoken-management) on Ethereum.
 
 ## Overview
 

--- a/docs/tutorials/proposals/update-asset-proposal.md
+++ b/docs/tutorials/proposals/update-asset-proposal.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 4
-title: Update an asset
+title: Propose asset update
 hide_title: false
 vega_network: TESTNET
 keywords:
@@ -24,7 +24,9 @@ import TabItem from '@theme/TabItem';
 
 # Propose an update to an asset
 
-Some of the properties on an asset can be changed through governance. Important fields such as the underlying contract, name and symbol cannot be changed.
+Some of the properties of an asset can be changed through governance. Those fields are: withdrawal and deposit limits, and the asset's quantum.
+
+The underlying contract, asset name and symbol cannot be changed.
 
 ## Requirements
 

--- a/docs/tutorials/proposals/update-market-proposal.md
+++ b/docs/tutorials/proposals/update-market-proposal.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: Propose an update to a market
+title: Propose updates to a market
 hide_title: false
 vega_network: TESTNET
 toc: true

--- a/scripts/libGenerateProposals/updateAsset.js
+++ b/scripts/libGenerateProposals/updateAsset.js
@@ -1,44 +1,50 @@
-const assert = require('assert').strict
-const { inspect } = require('util')
+const assert = require("assert").strict;
+const { inspect } = require("util");
 
-function updateAsset (skeleton) {
-  assert.ok(skeleton.properties.changes)
-  assert.ok(skeleton.properties.changes.properties.erc20)
+function updateAsset(skeleton) {
+  assert.ok(skeleton.properties.changes);
+  assert.ok(skeleton.properties.changes.properties.erc20);
   assert.ok(
     skeleton.properties.changes.properties.erc20.properties.withdrawThreshold
-  )
+  );
   assert.ok(
     skeleton.properties.changes.properties.erc20.properties.lifetimeLimit
-  )
+  );
 
   const result = {
     rationale: {
-      title: 'Update asset',
-      description: 'Proposal to change withdrawal threshold for asset'
+      title: "Update asset",
+      description: "Proposal to change withdrawal threshold for asset",
     },
     terms: {
       updateAsset: {
+        assetId:
+          "ebcd94151ae1f0d39a4bde3b21a9c7ae81a80ea4352fb075a92e07608d9c953d",
         changes: {
+          quantum: "1",
           erc20: {
-            withdrawThreshold: '10',
-            lifetimeLimit: '10'
-          }
-        }
-      }
-    }
-  }
+            withdrawThreshold: "10",
+            lifetimeLimit: "10",
+          },
+        },
+      },
+    },
+  };
 
   result.terms.updateAsset[inspect.custom] = () => {
     const withdrawThresholdSplit =
       skeleton.properties.changes.properties.erc20.properties.lifetimeLimit.title.split(
-        '\n'
-      )
+        "\n"
+      );
     const lifetimeLimitSplit =
       skeleton.properties.changes.properties.erc20.properties.lifetimeLimit.title.split(
-        '\n'
-      )
+        "\n"
+      );
     return `{
           changes: {
+            // ${skeleton.properties.changes.properties.quantum.title} (${skeleton.properties.changes.properties.quantum.type})
+            quantum: "1",
+
             erc20: {
               // ${withdrawThresholdSplit[0]}
               // ${withdrawThresholdSplit[1]} (${skeleton.properties.changes.properties.erc20.properties.withdrawThreshold.type})
@@ -48,9 +54,9 @@ function updateAsset (skeleton) {
               lifetimeLimit: "${result.terms.updateAsset.changes.erc20.lifetimeLimit}",
               }
         }
-    }`
-  }
-  return result
+    }`;
+  };
+  return result;
 }
 
-module.exports = { updateAsset }
+module.exports = { updateAsset };

--- a/scripts/libGenerateProposals/updateAsset.js
+++ b/scripts/libGenerateProposals/updateAsset.js
@@ -33,7 +33,7 @@ function updateAsset(skeleton) {
 
   result.terms.updateAsset[inspect.custom] = () => {
     const withdrawThresholdSplit =
-      skeleton.properties.changes.properties.erc20.properties.lifetimeLimit.title.split(
+      skeleton.properties.changes.properties.erc20.properties.withdrawThreshold.title.split(
         "\n"
       );
     const lifetimeLimitSplit =

--- a/scripts/libGenerateProposals/updateAsset.js
+++ b/scripts/libGenerateProposals/updateAsset.js
@@ -1,50 +1,44 @@
-const assert = require("assert").strict;
-const { inspect } = require("util");
+const assert = require('assert').strict
+const { inspect } = require('util')
 
-function updateAsset(skeleton) {
-  assert.ok(skeleton.properties.changes);
-  assert.ok(skeleton.properties.changes.properties.erc20);
+function updateAsset (skeleton) {
+  assert.ok(skeleton.properties.changes)
+  assert.ok(skeleton.properties.changes.properties.erc20)
   assert.ok(
     skeleton.properties.changes.properties.erc20.properties.withdrawThreshold
-  );
+  )
   assert.ok(
     skeleton.properties.changes.properties.erc20.properties.lifetimeLimit
-  );
+  )
 
   const result = {
     rationale: {
-      title: "Update asset",
-      description: "Proposal to change withdrawal threshold for asset",
+      title: 'Update asset',
+      description: 'Proposal to change withdrawal threshold for asset'
     },
     terms: {
       updateAsset: {
-        assetId:
-          "ebcd94151ae1f0d39a4bde3b21a9c7ae81a80ea4352fb075a92e07608d9c953d",
         changes: {
-          quantum: "1",
           erc20: {
-            withdrawThreshold: "10",
-            lifetimeLimit: "10",
-          },
-        },
-      },
-    },
-  };
+            withdrawThreshold: '10',
+            lifetimeLimit: '10'
+          }
+        }
+      }
+    }
+  }
 
   result.terms.updateAsset[inspect.custom] = () => {
     const withdrawThresholdSplit =
-      skeleton.properties.changes.properties.erc20.properties.withdrawThreshold.title.split(
-        "\n"
-      );
+      skeleton.properties.changes.properties.erc20.properties.lifetimeLimit.title.split(
+        '\n'
+      )
     const lifetimeLimitSplit =
       skeleton.properties.changes.properties.erc20.properties.lifetimeLimit.title.split(
-        "\n"
-      );
+        '\n'
+      )
     return `{
           changes: {
-            // ${skeleton.properties.changes.properties.quantum.title} (${skeleton.properties.changes.properties.quantum.type})
-            quantum: "1",
-
             erc20: {
               // ${withdrawThresholdSplit[0]}
               // ${withdrawThresholdSplit[1]} (${skeleton.properties.changes.properties.erc20.properties.withdrawThreshold.type})
@@ -54,9 +48,9 @@ function updateAsset(skeleton) {
               lifetimeLimit: "${result.terms.updateAsset.changes.erc20.lifetimeLimit}",
               }
         }
-    }`;
-  };
-  return result;
+    }`
+  }
+  return result
 }
 
-module.exports = { updateAsset };
+module.exports = { updateAsset }


### PR DESCRIPTION
> **NOTE**: #312 should be merged first, then this will need a rebase. This PR uses the `EthAddresses` component which changes enough in #312 that it's worth doing in that order. If not, this page is likely to display empty results for the ETH addresses

Document signature bundle submission to bridge

- Add new page to Proposals section (Note: this might not be the right section)
- Add one page that describes getting the signature bundle for *listing* an asset, and *updating* an asset

The procedure for both are similar enough that it felt right to keep them on the same page, ~but not to make it the same step by step process for both of them~ as separate lists.

Closes #234