### PR TITLE
Highlight which networks the CLI wallets need

### DIFF
--- a/docs/tools/vega-wallet/cli-wallet/latest/create-wallet.md
+++ b/docs/tools/vega-wallet/cli-wallet/latest/create-wallet.md
@@ -8,19 +8,20 @@ description: Set up your first wallet and keypair using the CLI wallet app
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-To download Vega Wallet and create your wallet, follow the step-by-step instructions below. This software a work-in-progress and is frequently updated. As of August 2022, the Vega Wallet software has moved from `vegawallet` to [`vega` ↗](https://github.com/vegaprotocol/vega/releases/) on GitHub, and the version numbers have changed. 
+To download Vega Wallet and create your wallet, follow the step-by-step instructions below. 
+
+This software is frequently updated. As of August 2022, the Vega Wallet software has moved from `vegawallet` to [`vega` ↗](https://github.com/vegaprotocol/vega/releases/) on GitHub, and the version numbers have changed. 
 
 :::caution
-These instructions cover version 0.54, which is only compatible with Vega network(s) that are also on 0.54.
+These instructions cover Vega Wallet version 0.55, which is only compatible with Vega network(s) that are also on v0.55. If  you need a Vega Wallet for mainnet, see [Create a wallet (mainnet)](https://docs.vega.xyz/docs/mainnet/tools/vega-wallet/cli-wallet/latest/create-wallet).
 :::
 
 Note: If you are looking for instructions for connecting your hardware wallet to MetaMask, see [MetaMask's guide ↗](https://metamask.zendesk.com/hc/en-us/articles/360020394612-How-to-connect-a-Trezor-or-Ledger-Hardware-Wallet).
 
+## Command line guidance
 Use the following instructions in command line. Below, you'll see commands in the code blocks for each operating system. Copy those instructions and paste them into your command line interface.
 
-:::info 
 In your command line interface, you can view a list of available commands by running `./vegawallet -h` on MacOS and Linux, or `vegawallet -h` on Windows. Help is also available for every command, for example: `vegawallet create -h` will provide information about the `create` command.
-:::
 
 ## 1. Install and run Vega Wallet
 

--- a/versioned_docs/version-v0.53/tools/vega-wallet/cli-wallet/latest/create-wallet.md
+++ b/versioned_docs/version-v0.53/tools/vega-wallet/cli-wallet/latest/create-wallet.md
@@ -7,21 +7,24 @@ hide_title: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-To download Vega Wallet and create your wallet, follow the step-by-step instructions below. This software a work-in-progress and is frequently updated. These instructions cover version 0.14 and newer.
+To download Vega Wallet and create your wallet, follow the step-by-step instructions below.
 
-Note: If you are looking for instructions for connecting your hardware wallet to MetaMask, see [MetaMask's guide](https://metamask.zendesk.com/hc/en-us/articles/360020394612-How-to-connect-a-Trezor-or-Ledger-Hardware-Wallet).
+Note: If you are looking for instructions for connecting your hardware wallet to MetaMask, see [MetaMask's guide ↗](https://metamask.zendesk.com/hc/en-us/articles/360020394612-How-to-connect-a-Trezor-or-Ledger-Hardware-Wallet).
 
+:::caution Wallet version
+The wallet software linked below is only compatible with the Vega mainnet network on v0.53. If you need a wallet for use with the Vega testnet, Fairground, see **[Create a wallet (testnet)](https://docs.vega.xyz/docs/testnet/tools/vega-wallet/cli-wallet/latest/create-wallet)**.
+:::
+
+## Command line guidance
 Use the following instructions in command line. Below, you'll see commands in the code blocks for each operating system. Copy those instructions and paste them into your command line interface.
 
-:::info 
 In your command line interface, you can view a list of available commands by running `./vegawallet -h` on MacOS and Linux, or `vegawallet -h` on Windows. Help is also available for every command, for example: `vegawallet create -h` will provide information about the `create` command.
-:::
 
 ## 1. Install and run Vega Wallet
 
 ### Download file
 
-**Download and save the zip file from [Vega Wallet software releases](https://github.com/vegaprotocol/vegawallet/releases/)**. Keep track of where you've saved the file, because that's where the command line interface will look for it.
+**Download and save the zip file from [Vega Wallet software releases ↗](https://github.com/vegaprotocol/vegawallet/releases/)**. Keep track of where you've saved the file, because that's where the command line interface will look for it.
 
 :::note You may need to change your system preferences to run the file. 
 
@@ -48,7 +51,7 @@ Click on the `(?)` help button, which will open a window that links you to the `
 
 You’ll need to go to `System Preferences` > `Security & Privacy` > `General`, and choose `Open Anyway`.
 
-[Apple also provides instructions for opening unsigned apps (Apple support)](https://support.apple.com/en-au/guide/mac-help/mh40616/mac)
+[Apple also provides instructions for opening unsigned apps (Apple support) ↗](https://support.apple.com/en-au/guide/mac-help/mh40616/mac)
 </TabItem>
 
 <TabItem value="linux" label="Linux">
@@ -144,8 +147,8 @@ If you want to interact with the Token dApp or Vega Console, you'll need to impo
 
 Import the following network configurations: 
 
-* **Mainnet** network (run by validators): [`mainnet1.toml`](https://raw.githubusercontent.com/vegaprotocol/networks/master/mainnet1/mainnet1.toml)
-* **Fairground** network: [`fairground.toml`](https://raw.githubusercontent.com/vegaprotocol/networks/master/fairground/fairground.toml)
+* **Mainnet** network (run by validators): [`mainnet1.toml` ↗](https://raw.githubusercontent.com/vegaprotocol/networks/master/mainnet1/mainnet1.toml)
+* **Fairground** network: [`fairground.toml` ↗](https://raw.githubusercontent.com/vegaprotocol/networks/master/fairground/fairground.toml)
 
 :::info
 To update your networks list, see [manage networks](/docs/testnet/tools/vega-wallet/cli-wallet/latest/guides/manage-networks#update-networks) for instructions.


### PR DESCRIPTION
As the CLI wallet software is so version-dependent, the pages could use more guidance to help people differentiate. This PR adds caution boxes with links to the other networks' wallet instructions.