### PR TITLE
Switch testnet to sepolia

### DIFF
--- a/docs/api/bridge/index.md
+++ b/docs/api/bridge/index.md
@@ -22,7 +22,7 @@ For an introduction to staking on Vega, [check out our Concepts section](../../c
 Used for depositing ERC20 tokens in to a Vega network.
 
 
-To read more about how the bridge works, [see this blog post](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Ropsten on to the Fairground testnet, head over to [Fairground Console](https://console.fairground.wtf).
+To read more about how the bridge works, [see this blog post](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Sepolia on to the Fairground testnet, head over to [Fairground Console](https://console.fairground.wtf).
 
 ## [Multisig Control](./interfaces/IMultisigControl.md)
 Used to control the ownership of bridge contracts, allowing the validators of a Vega network to control which assets can be used with the bridge, and approve asset withdrawals.

--- a/docs/api/bridge/index.md
+++ b/docs/api/bridge/index.md
@@ -1,7 +1,6 @@
 ---
 title: Overview
 vega_network: TESTNET
-ethereum_network: Ropsten
 sidebar_position: 1
 ---
 
@@ -11,14 +10,14 @@ There are three main components to the Vega <-> Ethereum bridge
 
 ## [Staking bridge](./interfaces/IStake.md)
 
-<EthAddresses frontMatter={frontMatter} show={["stakingBridge"]} />
+<EthAddresses frontMatter={frontMatter} show={["StakingBridge"]} />
 
 Allows users to stake locked or unlocked Vega tokens.
 
 For an introduction to staking on Vega, [check out our Concepts section](../../concepts/vega-chain.md#bridges-used-for-staking) or for a higher level overview [see this blog post](https://blog.vega.xyz/staking-on-vega-17f22113e3df).
 
 ## [ERC20 asset bridge](./interfaces/IERC20_Bridge_Logic.md)
-<EthAddresses frontMatter={frontMatter} show={["erc20Bridge"]} />
+<EthAddresses frontMatter={frontMatter} show={["ERC20Bridge"]} />
 
 Used for depositing ERC20 tokens in to a Vega network.
 

--- a/docs/tutorials/staking-tokens.md
+++ b/docs/tutorials/staking-tokens.md
@@ -2,7 +2,6 @@
 title: Stake tokens
 hide_title: false
 vega_network: TESTNET
-ethereum_network: Ropsten
 description: Stake unlocked tokens with Vega Wallet and smart contracts
 ---
 import EthAddresses from '@site/src/components/EthAddresses';

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@svgr/webpack": "6.3.1",
     "@vegaprotocol/docusaurus-theme-github-codeblock": "^0.1.8",
     "@vegaprotocol/openrpc-md": "1.2.2",
-    "@vegaprotocol/smart-contracts-sdk": "^1.6.0",
     "bignumber.js": "^9.0.2",
     "clsx": "^1.2.1",
     "date-fns": "^2.29.1",

--- a/scripts/version-switch.sh
+++ b/scripts/version-switch.sh
@@ -29,8 +29,6 @@ find 'docs/grpc' -type f -name '*.mdx' -exec sed -i -E 's/\/docs\/grpc/\/docs\/t
 
 ## Ensure frontmatter for non-testnet docs is set to mainnets
 find 'versioned_docs' -type f -name '*.mdx' -o -name '*.md' -exec sed -i -E 's/vega_network: TESTNET/vega_network: MAINNET/g' {} +
-find 'versioned_docs' -type f -name '*.mdx' -o -name '*.md' -exec sed -i -E 's/ethereum_network: ROPSTEN/ethereum_network: Mainnet/g' {} +
-find 'versioned_docs' -type f -name '*.mdx' -o -name '*.md' -exec sed -i -E 's/ethereum_network: Ropsten/ethereum_network: Mainnet/g' {} +
 
 ## Do the inverse, just in case
 find 'docs' -type f -name '*.mdx' -o -name '*.md' -exec sed -i -E 's/vega_network: MAINNET/vega_network: TESTNET/g' {} +

--- a/specs/mainnet_contracts.json
+++ b/specs/mainnet_contracts.json
@@ -1,0 +1,26 @@
+{
+	"network": "mainnet",
+	"MultisigControl": {
+		"address": "0x164D322B2377C0fdDB73Cd32f24e972A7d9C72F9",
+		"version": "v2"
+	},
+	"ERC20Bridge": {
+		"address": "0xCd403f722b76366f7d609842C589906ca051310f",
+		"version": "v2"
+	},
+	"ERC20AssetPool": {
+		"address": "0xF0f0FcDA832415b935802c6dAD0a6dA2c7EAed8f",
+		"version": "v1"
+	},
+	"StakingBridge": {
+		"address": "0x195064D33f09e0c42cF98E665D9506e0dC17de68",
+		"version": "v1"
+	},
+	"VestingBridge": {
+		"address": "0x23d1bFE8fA50a167816fBD79D7932577c06011f4",
+		"version": "v1"
+	},
+	"VegaToken": {
+		"address": "0xcB84d72e61e383767C4DFEb2d8ff7f4FB89abc6e"
+	}
+}

--- a/specs/testnet_contracts.json
+++ b/specs/testnet_contracts.json
@@ -1,0 +1,33 @@
+{
+	"network": "sepolia",
+	"MultisigControl": {
+		"address": "0x6eBc32d66277D94DB8FF2ccF86E36f37F29a52D3",
+		"version": "v2"
+	},
+	"ERC20Bridge": {
+		"address": "0x7fe27d970bc8Afc3B11Cc8d9737bfB66B1efd799",
+		"version": "v2"
+	},
+	"ERC20AssetPool": {
+		"address": "0x2Fe022FFcF16B515A13077e53B0a19b3e3447855",
+		"version": "v1"
+	},
+	"StakingBridge": {
+		"address": "0xFFb0A0d4806502ceF491aF1141f66669A1Bd0D03",
+		"version": "v1"
+	},
+	"VestingBridge": {
+		"address": "0x680fF88252FA7071CAce7398e77872d54D781d0B",
+		"version": "v1"
+	},
+	"VegaToken": {
+		"address": "0xdf1B0F223cb8c7aB3Ef8469e529fe81E73089BD9",
+		"version": "TokenBase",
+		"minter": "0x3c9BCb0B5BE9D1c4D75024BAA0d5D55aD354fa77"
+	},
+	"V1Token": {
+		"address": "0xB6943f22FfeB615C420911B38561b27718C91845",
+		"version": "TokenBase",
+		"minter": "0x3c9BCb0B5BE9D1c4D75024BAA0d5D55aD354fa77"
+	}
+}

--- a/src/components/EthAddresses.js
+++ b/src/components/EthAddresses.js
@@ -24,7 +24,7 @@ function etherscanLink(contractAddress, network) {
 
 const contractNames = {
   MultisigControl: "Multisig Control",
-  ERC20AssetPool: "ERC20 Aasset pool", 
+  ERC20AssetPool: "ERC20 Asset pool", 
   VegaToken: "Vega token",
   VestingBridge: "Token vesting",
   StakingBridge: "Staking bridge",

--- a/src/components/EthAddresses.js
+++ b/src/components/EthAddresses.js
@@ -50,7 +50,7 @@ export default function EthAddresses({ frontMatter, show }) {
   let showOnly = show ? show : showOnlyDefault;
 
   if (!vega_network) {
-    throw new Error("Missing vega_networ");
+    throw new Error("Missing vega_network");
   }
 
   const addresses = vega_network.toLowerCase() === 'mainnet' ? mainnetContracts : testnetContracts

--- a/src/components/EthAddresses.js
+++ b/src/components/EthAddresses.js
@@ -1,8 +1,10 @@
 import React from "react";
-import { EnvironmentConfig } from "@vegaprotocol/smart-contracts-sdk";
+import mainnetContracts from "../../specs/mainnet_contracts.json";
+import testnetContracts from "../../specs/testnet_contracts.json";
 
 const etherscanBase = {
   ropsten: "https://ropsten.etherscan.io/address/",
+  sepolia: "https://sepolia.etherscan.io/address/",
   mainnet: "https://etherscan.io/address/",
 };
 
@@ -21,19 +23,19 @@ function etherscanLink(contractAddress, network) {
 }
 
 const contractNames = {
-  vegaTokenAddress: "Vega token",
-  claimAddress: "Token claim addres",
-  lockedAddress: "Locked token proxy",
-  vestingAddress: "Token vesting",
-  stakingBridge: "Staking bridge",
-  erc20Bridge: "ERC20 Bridge",
+  MultisigControl: "Multisig Control",
+  ERC20AssetPool: "ERC20 Aasset pool", 
+  VegaToken: "Vega token",
+  VestingBridge: "Token vesting",
+  StakingBridge: "Staking bridge",
+  ERC20Bridge: "ERC20 Bridge",
 };
 
 const showOnlyDefault = [
-  "vegaTokenAddress",
-  "vestingAddress",
-  "stakingBridge",
-  "erc20Bridge",
+  "VegaToken",
+  "VestingBridge",
+  "StakingBridge",
+  "ERC20Bridge",
 ];
 
 /**
@@ -44,16 +46,18 @@ const showOnlyDefault = [
  * @returns
  */
 export default function EthAddresses({ frontMatter, show }) {
-  const { vega_network, ethereum_network } = frontMatter;
+  const { vega_network } = frontMatter;
   let showOnly = show ? show : showOnlyDefault;
 
-  if (!vega_network || !ethereum_network) {
-    throw new Error("Missing vega_network or ethereum_network");
+  if (!vega_network) {
+    throw new Error("Missing vega_networ");
   }
 
-  const addresses = EnvironmentConfig[vega_network];
+  const addresses = vega_network.toLowerCase() === 'mainnet' ? mainnetContracts : testnetContracts
+  const ethereum_network = addresses.network
+
   if (!addresses) {
-    throw new Error("Missing vega_network or ethereum_network");
+    throw new Error("Could not load addresses");
   }
 
   return (
@@ -68,7 +72,9 @@ export default function EthAddresses({ frontMatter, show }) {
       <tbody>
         {Object.keys(addresses)
           .filter(
-            (key) => addresses[key].length > 8 && showOnly.indexOf(key) !== -1
+            (key) => {
+              return showOnly.indexOf(key) !== -1
+            }
           )
           .map((key) => {
             return (
@@ -77,8 +83,8 @@ export default function EthAddresses({ frontMatter, show }) {
                   <strong>{contractNames[key]}</strong>
                 </td>
                 <td>
-                  <code>{addresses[key]}</code>{" "}
-                  {etherscanLink(addresses[key], ethereum_network)}
+                  <code>{addresses[key].address}</code>{" "}
+                  {etherscanLink(addresses[key].address, ethereum_network)}
                 </td>
                 <td align="center">{ethereum_network}</td>
               </tr>

--- a/versioned_docs/version-v0.53/api/bridge/index.md
+++ b/versioned_docs/version-v0.53/api/bridge/index.md
@@ -22,7 +22,7 @@ For an introduction to staking on Vega, [check out our Concepts section](../../c
 Used for depositing ERC20 tokens in to a Vega network.
 
 
-To read more about how the bridge works, [see this blog post](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Ropsten on to the Fairground testnet, head over to [Fairground Console](https://console.fairground.wtf).
+To read more about how the bridge works, [see this blog post](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Sepolia on to the Fairground testnet, head over to [Fairground Console](https://console.fairground.wtf).
 
 ## [Multisig Control](./interfaces/IMultisigControl.md)
 Used to control the ownership of bridge contracts, allowing the validators of a Vega network to control which assets can be used with the bridge, and approve asset withdrawals.

--- a/versioned_docs/version-v0.53/api/bridge/index.md
+++ b/versioned_docs/version-v0.53/api/bridge/index.md
@@ -1,7 +1,6 @@
 ---
 title: Overview
 vega_network: MAINNET
-ethereum_network: Mainnet
 sidebar_position: 1
 ---
 
@@ -11,14 +10,14 @@ There are three main components to the Vega <-> Ethereum bridge
 
 ## [Staking bridge](./interfaces/IStake.md)
 
-<EthAddresses frontMatter={frontMatter} show={["stakingBridge"]} />
+<EthAddresses frontMatter={frontMatter} show={["StakingBridge"]} />
 
 Allows users to stake locked or unlocked Vega tokens.
 
 For an introduction to staking on Vega, [check out our Concepts section](../../concepts/vega-chain.md#bridges-used-for-staking) or for a higher level overview [see this blog post](https://blog.vega.xyz/staking-on-vega-17f22113e3df).
 
 ## [ERC20 asset bridge](./interfaces/IERC20_Bridge_Logic.md)
-<EthAddresses frontMatter={frontMatter} show={["erc20Bridge"]} />
+<EthAddresses frontMatter={frontMatter} show={["ERC20Bridge"]} />
 
 Used for depositing ERC20 tokens in to a Vega network.
 

--- a/versioned_docs/version-v0.53/tutorials/staking-tokens.md
+++ b/versioned_docs/version-v0.53/tutorials/staking-tokens.md
@@ -2,7 +2,6 @@
 title: Stake tokens
 hide_title: false
 vega_network: MAINNET
-ethereum_network: Mainnet
 ---
 
 import EthAddresses from '@site/src/components/EthAddresses';


### PR DESCRIPTION
Update docs for Sepolia

- Remove @vegaprotocol/smart-contracts-sdk dependency, it is deprecated
- Add json files containing contract addresses
- Remove Ethereum_Network frontmatter in favour of eth network in json
  file
- Update EthereumAddresses component to match new labels

Closes #123
