### PR TITLE
Fix details component styling in non-REST docs

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -327,3 +327,23 @@ a.external:after {
   color: var(--ifm-color-secondary-contrast-foreground);
   border-color: var(--ifm-color-secondary-dark);
 } 
+
+/* Fix for details element style override in openapi docs */
+.row .col.col--12 details {
+  --docusaurus-details-decoration-color: var(--ifm-alert-border-color) !important;
+  --docusaurus-details-transition: transform var(--ifm-transition-fast) ease !important;
+  background-color: var(--ifm-alert-background-color);
+  border: var(--ifm-alert-border-width) solid var(--ifm-alert-border-color);
+  border-left-width: var(--ifm-alert-border-left-width);
+  margin: 0 0 var(--ifm-spacing-vertical) !important;
+  box-shadow: var(--ifm-alert-shadow);
+  color: var(--ifm-alert-foreground-color);
+  padding: var(--ifm-alert-padding-vertical) var(--ifm-alert-padding-horizontal);
+}
+
+/* Fix for details element style override in openapi docs */
+.row .col.col--12 details > div {
+  margin-top: 1rem;
+  border-top: 1px solid var(--docusaurus-details-decoration-color);
+  padding-top: 1rem; 
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -254,13 +254,13 @@ a.external:after {
 
 /* Topic stubs */
 
-.stub [class*='details'] {
-  background: var( --ifm-color-secondary-contrast-background );
-  border-color: var(--ifm-color-secondary-dark);
-  --docusaurus-details-decoration-color: var(--ifm-color-secondary-darkest);
+.col--12 .stub [class*='details'] {
+  background: var( --ifm-color-secondary-contrast-background ) !important;
+  border-color: var(--ifm-color-secondary-dark) !important;
+  --docusaurus-details-decoration-color: var(--ifm-color-secondary-darkest) !important;
 }
 
-.stub [class*='details'] a {
+.col--12 .stub [class*='details'] a {
     text-decoration-color: var(--ifm-color-secondary-darkest);
 }
 
@@ -329,7 +329,7 @@ a.external:after {
 } 
 
 /* Fix for details element style override in openapi docs */
-.row .col.col--12 details {
+.row .col--12 details {
   --docusaurus-details-decoration-color: var(--ifm-alert-border-color) !important;
   --docusaurus-details-transition: transform var(--ifm-transition-fast) ease !important;
   background-color: var(--ifm-alert-background-color);


### PR DESCRIPTION
This reinstates the original styles, by overriding the overrides in the REST theme

- Add styles to custom.css

Closes #318

# Screenshots

## The REST document details are unchanged
<img width="920" alt="Screenshot 2022-10-06 at 10 42 13" src="https://user-images.githubusercontent.com/6678/194343452-07f7f05d-d283-4e8e-ad5c-21202ac0f110.png">

## Before
<img width="645" alt="Screenshot 2022-10-06 at 10 42 27" src="https://user-images.githubusercontent.com/6678/194343535-7ffbb4a6-5eca-4224-bf3c-7f826b3552c8.png">

## After
<img width="662" alt="Screenshot 2022-10-06 at 10 42 48" src="https://user-images.githubusercontent.com/6678/194343569-ba315597-c69e-4b56-8344-60639ea6e126.png">



