### PR TITLE
Demonstrate endEpoch in recurring transfers

### DIFF
--- a/docs/tutorials/transferring-assets.md
+++ b/docs/tutorials/transferring-assets.md
@@ -73,7 +73,8 @@ You'll need the following information to set up a recurring transfer:
 * `startEpoch`: The number of the epoch in which you want the first transfer to be made. It will initiate at the end of that epoch.
 * `factor`: Written as a decimal less than 1.0. Factor is used to determine what portion of the full `amount` is transferred in each epoch. Think of it like a percentage, so the number you include, when multiplied by 100, will equal what percentage of the amount will be transferred each time. 
 
-If you do not have enough to cover each transfer and its fee, the transfer will automatically be cancelled.
+If you do not have enough to cover each transfer and its fee, the transfer will automatically be cancelled. The transfer will repeated indefinitely, unless you add the optional parameter to end the recurring transfer:
+* `endEpoch`: The number of the epoch in which you want the last transfer to be made.
 
 <Tabs groupId="KeytoKeytransferRepeat">
 <TabItem value="KeytoKeytransferRepeatLinuxcmd" label="Linux / OSX command line">
@@ -88,6 +89,7 @@ vegawallet command send --wallet "wallet-name" --pubkey "pubkey" --network fairg
         "amount": "10000000000000000000",
         "recurring": {
             "startEpoch": 1,
+            "endEpoch": 10,
             "factor": "2"
         }
     }
@@ -107,6 +109,7 @@ vegawallet.exe command send --wallet "wallet-name" --pubkey "pubkey" --network f
         \"amount\":\"10000000000000000000\", ^
         \"recurring\":{ ^
             \"startEpoch\": 1, ^
+            \"startEpoch\": 10, ^
             \"factor\": \"3\" ^
         } ^
     } ^
@@ -123,6 +126,9 @@ You'll need the following information to set up a reward:
 * `factor`: Written as a decimal less than 1.0. Factor is used to determine what portion of the full `amount` is transferred in each epoch. Think of it like a percentage, so the number you include, when multiplied by 100, will equal what percentage of the amount will be transferred each time. 
 
 Recurring transfers can also set a [dispatch strategy](../grpc/vega/vega.proto.mdx#dispatchstrategy) to distribute rewards based on [dispatch metrics](../grpc/vega/vega.proto.mdx#dispatchmetric) that are tracked by the system. The recurring reward transfer below would reward the public key that proposed the markets specified, depending on their value.
+
+The transfer will run indefinitely, unless you add the optional paramter to specify when to stop:
+* `endEpoch`: The number of the epoch in which you want the last transfer to be made.
  
 <Tabs groupId="KeytoPooltransferRepeat">
 <TabItem value="KeytoPooltransferRepeatLinuxcmd" label="Linux / OSX command line">
@@ -137,6 +143,7 @@ vegawallet command send --wallet "wallet-name" --pubkey "pubkey" --network fairg
         "amount":"10000000000000000000",
         "recurring":{
             "startEpoch": 1,
+            "endEpoch": 10,
             "factor": "3",
             "dispatchStrategy": {
                 "assetForMetric": "123",
@@ -162,6 +169,7 @@ vegawallet.exe command send --wallet "wallet-name" --pubkey "pubkey" --network f
         \"reference\":\"reward\", ^
         \"recurring\":{ ^
             \"startEpoch\": 1, ^
+            \"endEpoch\": 10, ^
             \"factor\": \"3\", ^
             \"dispatchStrategy\": { ^
                 \"metric\": \"DISPATCH_METRIC_MARKET_VALUE\", ^

--- a/docs/tutorials/transferring-assets.md
+++ b/docs/tutorials/transferring-assets.md
@@ -90,7 +90,7 @@ vegawallet command send --wallet "wallet-name" --pubkey "pubkey" --network fairg
         "recurring": {
             "startEpoch": 1,
             "endEpoch": 10,
-            "factor": "2"
+            "factor": "1"
         }
     }
 }'
@@ -109,8 +109,8 @@ vegawallet.exe command send --wallet "wallet-name" --pubkey "pubkey" --network f
         \"amount\":\"10000000000000000000\", ^
         \"recurring\":{ ^
             \"startEpoch\": 1, ^
-            \"startEpoch\": 10, ^
-            \"factor\": \"3\" ^
+            \"endEpoch\": 10, ^
+            \"factor\": \"1\" ^
         } ^
     } ^
 }"
@@ -144,9 +144,9 @@ vegawallet command send --wallet "wallet-name" --pubkey "pubkey" --network fairg
         "recurring":{
             "startEpoch": 1,
             "endEpoch": 10,
-            "factor": "3",
+            "factor": "1",
             "dispatchStrategy": {
-                "assetForMetric": "123",
+                "assetForMetric": "fc7fd956078fb1fc9db5c19b88f0874c4299b2a7639ad05a47a28c0aef291b55",
                 "metric": "DISPATCH_METRIC_MARKET_VALUE",
                 "markets": ["marketid"]
             }
@@ -165,12 +165,12 @@ vegawallet.exe command send --wallet "wallet-name" --pubkey "pubkey" --network f
         \"toAccountType\": \"ACCOUNT_TYPE_REWARD_MARKET_PROPOSERS\", ^
         \"to\":\"0000000000000000000000000000000000000000000000000000000000000000\", ^
         \"asset\":\"fc7fd956078fb1fc9db5c19b88f0874c4299b2a7639ad05a47a28c0aef291b55\", ^
-        \"amount\":\"10000000000000000000\", ^
+        \"amount\":\"fc7fd956078fb1fc9db5c19b88f0874c4299b2a7639ad05a47a28c0aef291b55\", ^
         \"reference\":\"reward\", ^
         \"recurring\":{ ^
             \"startEpoch\": 1, ^
             \"endEpoch\": 10, ^
-            \"factor\": \"3\", ^
+            \"factor\": \"1\", ^
             \"dispatchStrategy\": { ^
                 \"metric\": \"DISPATCH_METRIC_MARKET_VALUE\", ^
                 \"markets\": [\"marketid\"] ^

--- a/docs/tutorials/transferring-assets.md
+++ b/docs/tutorials/transferring-assets.md
@@ -73,7 +73,7 @@ You'll need the following information to set up a recurring transfer:
 * `startEpoch`: The number of the epoch in which you want the first transfer to be made. It will initiate at the end of that epoch.
 * `factor`: Written as a decimal less than 1.0. Factor is used to determine what portion of the full `amount` is transferred in each epoch. Think of it like a percentage, so the number you include, when multiplied by 100, will equal what percentage of the amount will be transferred each time. 
 
-If you do not have enough to cover each transfer and its fee, the transfer will automatically be cancelled. The transfer will repeated indefinitely, unless you add the optional parameter to end the recurring transfer:
+If you do not have enough to cover each transfer and its fee, the transfer will automatically be cancelled. Otherwise, the transfer will repeated indefinitely, unless you add the optional parameter to end the recurring transfer:
 * `endEpoch`: The number of the epoch in which you want the last transfer to be made.
 
 <Tabs groupId="KeytoKeytransferRepeat">

--- a/versioned_docs/version-v0.53/tutorials/transferring-assets.md
+++ b/versioned_docs/version-v0.53/tutorials/transferring-assets.md
@@ -72,7 +72,7 @@ You'll need the following information to set up a recurring transfer:
 * `startEpoch`: The number of the epoch in which you want the first transfer to be made. It will initiate at the end of this epoch.
 * `factor`: Written as a decimal less than 1.0, this is the factor used to determine what portion of the full `amount` is transferred in each epoch. Think of it like a percentage, so the number you include, when multiplied by 100, will equal what percentage of the amount you have available will be transferred each time. 
 
-If you do not have enough to cover each transfer and its fee, the transfer will automatically be cancelled. The transfer will repeated indefinitely, unless you add the optional parameter to end the recurring transfer:
+If you do not have enough to cover each transfer and its fee, the transfer will automatically be cancelled. Otherwise, the transfer will repeated indefinitely, unless you add the optional parameter to end the recurring transfer:
 * `endEpoch`: The number of the epoch in which you want the last transfer to be made
 
 <Tabs groupId="KeytoKeytransferRepeat">

--- a/versioned_docs/version-v0.53/tutorials/transferring-assets.md
+++ b/versioned_docs/version-v0.53/tutorials/transferring-assets.md
@@ -48,8 +48,8 @@ vegawallet command send --wallet "wallet-name" --pubkey "pubkey" --network fairg
 <TabItem value="KeytoKeytransferOnceWincmd" label="Windows command line example">
 
 ```bash
-vegawallet.exe command send --wallet "wallet-name" --pubkey "pubkey" --network fairground^
-"{\"transfer\":^
+vegawallet.exe command send --wallet "wallet-name" --pubkey "pubkey" --network mainnet1 ^
+"{\"transfer\": ^
     { ^
         \"fromAccountType\":\"ACCOUNT_TYPE_GENERAL\", ^
         \"toAccountType\":\"ACCOUNT_TYPE_GENERAL\", ^
@@ -76,7 +76,7 @@ You'll need the following information to set up a recurring transfer:
 <TabItem value="KeytoKeytransferRepeatLinuxcmd" label="Linux / OSX command line">
 
 ```bash
-vegawallet command send --wallet "wallet-name" --pubkey "pubkey" --network fairground '{
+vegawallet command send --wallet "wallet-name" --pubkey "pubkey" --network mainnet1 '{
     "transfer":{
         "fromAccountType":"ACCOUNT_TYPE_GENERAL",
         "toAccountType": "ACCOUNT_TYPE_GENERAL",
@@ -85,7 +85,8 @@ vegawallet command send --wallet "wallet-name" --pubkey "pubkey" --network fairg
         "amount": "10000000000000000000",
         "recurring": {
             "startEpoch": 1,
-            "factor": "2"
+            "endEpoch": 10,
+            "factor": "1"
         }
     }
 }'
@@ -94,7 +95,7 @@ vegawallet command send --wallet "wallet-name" --pubkey "pubkey" --network fairg
 <TabItem value="KeytoKeytransferRepeatcmdWin" label="Windows command line example">
 
 ```bash
-vegawallet.exe command send --wallet "wallet-name" --pubkey "pubkey" --network fairground^
+vegawallet.exe command send --wallet "wallet-name" --pubkey "pubkey" --network mainnet1 ^
 "{\"transfer\": ^
     { ^
         \"fromAccountType\": \"ACCOUNT_TYPE_GENERAL\", ^
@@ -104,7 +105,8 @@ vegawallet.exe command send --wallet "wallet-name" --pubkey "pubkey" --network f
         \"amount\":\"10000000000000000000\", ^
         \"recurring\":{ ^
             \"startEpoch\": 1, ^
-            \"factor\": \"3\" ^
+            \"startEpoch\": 10, ^
+            \"factor\": \"1\" ^
         } ^
     } ^
 }"

--- a/versioned_docs/version-v0.53/tutorials/transferring-assets.md
+++ b/versioned_docs/version-v0.53/tutorials/transferring-assets.md
@@ -72,6 +72,9 @@ You'll need the following information to set up a recurring transfer:
 * `startEpoch`: The number of the epoch in which you want the first transfer to be made. It will initiate at the end of this epoch.
 * `factor`: Written as a decimal less than 1.0, this is the factor used to determine what portion of the full `amount` is transferred in each epoch. Think of it like a percentage, so the number you include, when multiplied by 100, will equal what percentage of the amount you have available will be transferred each time. 
 
+If you do not have enough to cover each transfer and its fee, the transfer will automatically be cancelled. The transfer will repeated indefinitely, unless you add the optional parameter to end the recurring transfer:
+* `endEpoch`: The number of the epoch in which you want the last transfer to be made
+
 <Tabs groupId="KeytoKeytransferRepeat">
 <TabItem value="KeytoKeytransferRepeatLinuxcmd" label="Linux / OSX command line">
 


### PR DESCRIPTION
Add `endEpoch` to transfers examples & documentation

The param is optional, but very useful - rather than omit it, this PR adds it to the example code and describes it
in the sections about recurring transfers.

- Add `endEpoch` to recurring transfers tutorial

Closes #330
