### PR TITLE
Fix broken search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -186,7 +186,7 @@ module.exports = {
         hashed: true,
         explicitSearchResultPath: true,
         indexBlog: false,
-        docsRouteBasePath: ["/docs"],
+        docsRouteBasePath: ["/"],
       },
     ],
     [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@apidevtools/swagger-parser": "^10.1.0",
     "@docusaurus/core": "^2.1.0",
     "@docusaurus/preset-classic": "^2.1.0",
-    "@easyops-cn/docusaurus-search-local": "0.32.0",
+    "@easyops-cn/docusaurus-search-local": "0.33.5",
     "@edno/docusaurus2-graphql-doc-generator": "^1.13.1",
     "@graphql-tools/url-loader": "^7.13.3",
     "@mdx-js/react": "^1.6.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1867,10 +1867,10 @@
     cssesc "^3.0.0"
     immediate "^3.2.3"
 
-"@easyops-cn/docusaurus-search-local@0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.32.0.tgz#125bf88e7d013c6265c87abaa27262991eb31cb1"
-  integrity sha512-WB5695Rez9q8DbP9h89JyWo0U1Th1vA1R0dytJD/77M7Xxb/pFFwG5SCd0uzHF/ban0bmsTa96MxWYeDXwQzYA==
+"@easyops-cn/docusaurus-search-local@0.33.5":
+  version "0.33.5"
+  resolved "https://registry.yarnpkg.com/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.33.5.tgz#8048b75c860b0ab0eb007159aa13b04ac0c72078"
+  integrity sha512-9juHGVUy6N37Ezg1Msz1paMqT3zrQIlRLNJVw/NTG3aSctaYw1W0zAIRieXgBKvBAPkcCn95GsUrcziH13Grsw==
   dependencies:
     "@docusaurus/plugin-content-docs" "^2.0.0-rc.1"
     "@docusaurus/theme-translations" "^2.0.0-rc.1"


### PR DESCRIPTION
Search is broken in the current deployment. This fixes it.

It broken when #327 switched us from having /docs as the base path. The search plugin was looking
for that, seeing nothing, and building an empty index. A quick config change fixes it. This PR
also updates the plugin.

- Update @easyops-cn/docusaurus-search-local to 0.33.5
- Fix plugin config to use correct base path

Closes #355
