### PR TITLE
Fix DataNodes table matching for some hosts & add refresh time

### DIFF
--- a/scripts/build-pre-vaguer.sh
+++ b/scripts/build-pre-vaguer.sh
@@ -15,6 +15,8 @@ if ((mainnet_temp_good > 3)); then
   echo "   - New run: ${mainnet_temp_good}, old run: ${mainnet_current_good}"
   rm "./specs/mainnet_vaguer.json"
   mv "./specs/mainnet_vaguer_temp.json" "./specs/mainnet_vaguer.json"
+  rm -f "./specs/mainnet_vaguer_timestamp.json"
+  echo "{\"date\": \"$(date -u)\", \"timestamp\": \"$(date +%s)\"}" > "./specs/mainnet_vaguer_timestamp.json"
 else
   echo "   - 0 good nodes, doing nothing"
   rm "./specs/mainnet_vaguer_temp.json"
@@ -30,6 +32,8 @@ if ((testnet_temp_good > 3)); then
   echo "   - New run ${testnet_temp_good}, old run: ${testnet_current_good}"
   rm "./specs/testnet_vaguer.json"
   mv "./specs/testnet_vaguer_temp.json" "./specs/testnet_vaguer.json"
+  rm -f "./specs/testnet_vaguer_timestamp.json"
+  echo "{\"date\": \"$(date -u)\", \"timestamp\": \"$(date +%s)\"}" > "./specs/testnet_vaguer_timestamp.json"
 else
   echo "   - 0 good nodes, doing nothing"
   rm "./specs/testnet_vaguer_temp.json"

--- a/specs/mainnet_vaguer_timestamp.json
+++ b/specs/mainnet_vaguer_timestamp.json
@@ -1,0 +1,1 @@
+{"date": "Fri  4 Nov 2022 17:35:17 UTC", "timestamp": "1667583317"}

--- a/specs/testnet_vaguer_timestamp.json
+++ b/specs/testnet_vaguer_timestamp.json
@@ -1,0 +1,1 @@
+{"date": "Fri  4 Nov 2022 17:35:25 UTC", "timestamp": "1667583325"}

--- a/src/components/DataNodes.js
+++ b/src/components/DataNodes.js
@@ -1,8 +1,10 @@
 import React from "react";
 import mainnetNodes from "../../specs/mainnet_network.json";
 import mainnetNodesVaguer from "../../specs/mainnet_vaguer.json";
+import mainnetNodesVaguerTimestamp from "../../specs/mainnet_vaguer_timestamp.json";
 import testnetNodes from "../../specs/testnet_network.json";
 import testnetNodesVaguer from "../../specs/testnet_vaguer.json";
+import testnetNodesVaguerTimestamp from "../../specs/testnet_vaguer_timestamp.json";
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -15,8 +17,8 @@ function getHostname(url) {
     if (match && match.length > 2) {
         const host = match[2]
 
-        // Make a nice 
-        return host.replace('.vega.community', '')
+        // Some special cases
+        return host.replace('.vega.community', '').replace('grpc.', '')
     }
     return url
 }
@@ -61,7 +63,7 @@ function TableForNodes(listOfNodes, vaguerResult) {
                     <td>
                         <code>{n.host}</code>
                     </td>
-                    <td align="center">{n.good === true ? '✅' : ''}</td>
+                    <td align="center">{n.good === true ? '⭐' : ''}</td>
                 </tr>
                 );
             })}
@@ -88,7 +90,7 @@ export default function DataNodes({ frontMatter }) {
   const addresses = isMainnet ? mainnetNodes.API : testnetNodes.API
   const vaguer = isMainnet ? mainnetNodesVaguer : testnetNodesVaguer
   const source = isMainnet ? 'https://github.com/vegaprotocol/networks' : 'https://github.com/vegaprotocol/networks-internal'
-
+  const d = isMainnet ? mainnetNodesVaguerTimestamp : testnetNodesVaguerTimestamp 
   if (!addresses) {
     throw new Error("Could not load addresses");
   }
@@ -100,7 +102,8 @@ export default function DataNodes({ frontMatter }) {
             <TabItem value="graphql" label="GraphQL">{TableForNodes(addresses.GraphQL.Hosts, vaguer)}</TabItem>
             <TabItem value="rest" label="REST">{TableForNodes(addresses.REST.Hosts, vaguer)}</TabItem>
         </Tabs>
-        <p>Source: <a href={source} className="external" target="_blank" rel="noopener nofollow">{source.replace('https://', '')}</a></p>
+        <p style={{fontSize: "0.7em", marginTop: '0'}}><strong>Source:</strong> <a href={source} className="external" target="_blank" rel="noopener nofollow">{source.replace('https://', '')}</a><br />
+        <strong>Last refreshed:</strong> <em>{d.date}</em></p>
     </div>
     );
 }


### PR DESCRIPTION
Fixes mistmatches between nodes with different subdomains for some APIs.
Also adds a refresh time, so it's clear when the connection star was last checked

- Fix DataNode host matching
- Add refresh time json
- Add refresh time below table

<img width="651" alt="Screenshot 2022-11-04 at 17 42 35" src="https://user-images.githubusercontent.com/6678/200041179-4ccd5afe-c534-41a4-88ec-c97891c04397.png">

Closes #352
