### PR TITLE
Fix title and description on homepage

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,8 +3,8 @@
 const { shortenVersion, openApiConfig, version, mainnetVersion } = require('./scripts/docusaurus.config.openapi.js')
 
 module.exports = {
-  title: "Vega Protocol",
-  tagline: "A protocol for creating and trading derivatives on a fully decentralised network",
+  title: "Vega Protocol Documentation",
+  tagline: "Documentation of a protocol for creating and trading derivatives on a fully decentralised network",
   url: "https://docs.vega.xyz/",
   baseUrl: "/",
   trailingSlash: false,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -20,7 +20,7 @@ function HomepageHeader() {
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
   return (
-    <Layout title={`${siteConfig.title}`} description="${siteConfig.tagline}">
+    <Layout description={`${siteConfig.tagline}`}>
       <HomepageHeader />
       <main>
         <section id="topics">


### PR DESCRIPTION
closes #402 

Before

<img width="700" alt="Screenshot 2022-12-01 at 16 10 11" src="https://user-images.githubusercontent.com/13255539/205102740-2f5eee08-2b12-4583-8c10-595bd6596c1e.png">

After

<img width="700" alt="Screenshot 2022-12-01 at 16 11 08" src="https://user-images.githubusercontent.com/13255539/205102906-efcb3118-76b6-470c-a513-926a39cf42c5.png">

Should improve the preview content that you get when linking to docs from discord twitter etc.

I've made a request for an image [here](https://github.com/vegaprotocol/ux-and-visual-design/issues/85)
