### PR TITLE
feat(proposals): add dates to newmarket metadata and reduce randomness

### DIFF
--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
@@ -2,17 +2,17 @@
   ```javascript
 {
  rationale: {
-  title: "Add tEuro (tEURO)",
-  description: "Proposal to add tEuro (tEURO) as an asset"
+  title: "Add tDAI TEST (tDAI)",
+  description: "Proposal to add tDAI TEST (tDAI) as an asset"
  },
  terms: {
   newAsset: {
    changes: {
     // Name of the asset (e.g: Great British Pound) (string) 
-    name: "tEuro",
+    name: "tDAI TEST",
 
     // Symbol of the asset (e.g: GBP) (string) 
-    symbol: "tEURO",
+    symbol: "tDAI",
 
     // Number of decimal / precision handled by this asset (string) 
     decimals: "18",
@@ -23,7 +23,7 @@
     // An Ethereum ERC20 asset
     erc20: {
      // The address of the contract for the token, on the ethereum network (string)
-     contractAddress: "0x0158031158Bb4dF2AD02eAA31e8963E84EA978a4",
+     contractAddress: "0x26223f9C67871CFcEa329975f7BC0C9cB8FBDb9b",
 
      // The maximum you can withdraw instantly. All withdrawals over the threshold will be delayed by the withdrawal delay.
      // There’s no limit on the size of a withdrawal (string)
@@ -38,14 +38,14 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1674678991,
+  closingTimestamp: undefined,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1674765391,
+  enactmentTimestamp: undefined,
 
   // Validation timestamp (Unix time in seconds) (int64 as string)
-  validationTimestamp: 1674592591
+  validationTimestamp: undefined
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
@@ -38,14 +38,14 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: undefined,
+  closingTimestamp: 1675103064000,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: undefined,
+  enactmentTimestamp: 1675189464000,
 
   // Validation timestamp (Unix time in seconds) (int64 as string)
-  validationTimestamp: undefined
+  validationTimestamp: 1675189464000
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
@@ -19,7 +19,10 @@
       "lifetimeLimit": "10"
      }
     }
-   }
+   },
+   "closingTimestamp": 1675103064000,
+   "enactmentTimestamp": 1675189464000,
+   "validationTimestamp": 1675189464000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
@@ -3,26 +3,23 @@
 ./vegawallet transaction send --wallet your_walletname --pubkey your_public_key --network fairground '{
  "proposalSubmission": {
   "rationale": {
-   "title": "Add tEuro (tEURO)",
-   "description": "Proposal to add tEuro (tEURO) as an asset"
+   "title": "Add tDAI TEST (tDAI)",
+   "description": "Proposal to add tDAI TEST (tDAI) as an asset"
   },
   "terms": {
    "newAsset": {
     "changes": {
-     "name": "tEuro",
-     "symbol": "tEURO",
+     "name": "tDAI TEST",
+     "symbol": "tDAI",
      "decimals": "18",
      "quantum": "1",
      "erc20": {
-      "contractAddress": "0x0158031158Bb4dF2AD02eAA31e8963E84EA978a4",
+      "contractAddress": "0x26223f9C67871CFcEa329975f7BC0C9cB8FBDb9b",
       "withdrawThreshold": "10",
       "lifetimeLimit": "10"
      }
     }
-   },
-   "closingTimestamp": 1674678991,
-   "enactmentTimestamp": 1674765391,
-   "validationTimestamp": 1674592591
+   }
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
@@ -18,7 +18,10 @@
           "lifetimeLimit": "10"
         }
       }
-    }
+    },
+    "closingTimestamp": 1675103064000,
+    "enactmentTimestamp": 1675189464000,
+    "validationTimestamp": 1675189464000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
@@ -2,26 +2,23 @@
   ```json
 {
   "rationale": {
-    "title": "Add tEuro (tEURO)",
-    "description": "Proposal to add tEuro (tEURO) as an asset"
+    "title": "Add tDAI TEST (tDAI)",
+    "description": "Proposal to add tDAI TEST (tDAI) as an asset"
   },
   "terms": {
     "newAsset": {
       "changes": {
-        "name": "tEuro",
-        "symbol": "tEURO",
+        "name": "tDAI TEST",
+        "symbol": "tDAI",
         "decimals": "18",
         "quantum": "1",
         "erc20": {
-          "contractAddress": "0x0158031158Bb4dF2AD02eAA31e8963E84EA978a4",
+          "contractAddress": "0x26223f9C67871CFcEa329975f7BC0C9cB8FBDb9b",
           "withdrawThreshold": "10",
           "lifetimeLimit": "10"
         }
       }
-    },
-    "closingTimestamp": 1674678991,
-    "enactmentTimestamp": 1674765391,
-    "validationTimestamp": 1674592591
+    }
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
@@ -4,26 +4,23 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
 "{^
 \"proposalSubmission\": {^
  \"rationale\": {^
-  \"title\": \"Add tEuro (tEURO)\",^
-  \"description\": \"Proposal to add tEuro (tEURO) as an asset\"^
+  \"title\": \"Add tDAI TEST (tDAI)\",^
+  \"description\": \"Proposal to add tDAI TEST (tDAI) as an asset\"^
  },^
  \"terms\": {^
   \"newAsset\": {^
    \"changes\": {^
-    \"name\": \"tEuro\",^
-    \"symbol\": \"tEURO\",^
+    \"name\": \"tDAI TEST\",^
+    \"symbol\": \"tDAI\",^
     \"decimals\": \"18\",^
     \"quantum\": \"1\",^
     \"erc20\": {^
-     \"contractAddress\": \"0x0158031158Bb4dF2AD02eAA31e8963E84EA978a4\",^
+     \"contractAddress\": \"0x26223f9C67871CFcEa329975f7BC0C9cB8FBDb9b\",^
      \"withdrawThreshold\": \"10\",^
      \"lifetimeLimit\": \"10\"^
     }^
    }^
-  },^
-  \"closingTimestamp\": 1674678991,^
-  \"enactmentTimestamp\": 1674765391,^
-  \"validationTimestamp\": 1674592591^
+  }^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
@@ -20,7 +20,10 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
      \"lifetimeLimit\": \"10\"^
     }^
    }^
-  }^
+  },^
+  \"closingTimestamp\": 1675103064000,^
+  \"enactmentTimestamp\": 1675189464000,^
+  \"validationTimestamp\": 1675189464000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
@@ -13,7 +13,7 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string})
-  closingTimestamp: undefined,
+  closingTimestamp: 1675103064000,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
@@ -13,7 +13,7 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string})
-  closingTimestamp: 1674678991,
+  closingTimestamp: undefined,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
@@ -7,8 +7,7 @@
    "description": "I propose that everyone evaluate the following IPFS document and vote Yes if they agree. [bafybeigwwctpv37xdcwacqxvekr6e4kaemqsrv34em6glkbiceo3fcy4si](https://dweb.link/ipfs/bafybeigwwctpv37xdcwacqxvekr6e4kaemqsrv34em6glkbiceo3fcy4si)"
   },
   "terms": {
-   "newFreeform": {},
-   "closingTimestamp": 1674678991
+   "newFreeform": {}
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
@@ -7,7 +7,8 @@
    "description": "I propose that everyone evaluate the following IPFS document and vote Yes if they agree. [bafybeigwwctpv37xdcwacqxvekr6e4kaemqsrv34em6glkbiceo3fcy4si](https://dweb.link/ipfs/bafybeigwwctpv37xdcwacqxvekr6e4kaemqsrv34em6glkbiceo3fcy4si)"
   },
   "terms": {
-   "newFreeform": {}
+   "newFreeform": {},
+   "closingTimestamp": 1675103064000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
@@ -6,8 +6,7 @@
     "description": "I propose that everyone evaluate the following IPFS document and vote Yes if they agree. [bafybeigwwctpv37xdcwacqxvekr6e4kaemqsrv34em6glkbiceo3fcy4si](https://dweb.link/ipfs/bafybeigwwctpv37xdcwacqxvekr6e4kaemqsrv34em6glkbiceo3fcy4si)"
   },
   "terms": {
-    "newFreeform": {},
-    "closingTimestamp": 1674678991
+    "newFreeform": {}
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
@@ -6,7 +6,8 @@
     "description": "I propose that everyone evaluate the following IPFS document and vote Yes if they agree. [bafybeigwwctpv37xdcwacqxvekr6e4kaemqsrv34em6glkbiceo3fcy4si](https://dweb.link/ipfs/bafybeigwwctpv37xdcwacqxvekr6e4kaemqsrv34em6glkbiceo3fcy4si)"
   },
   "terms": {
-    "newFreeform": {}
+    "newFreeform": {},
+    "closingTimestamp": 1675103064000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
@@ -8,8 +8,7 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
   \"description\": \"I propose that everyone evaluate the following IPFS document and vote Yes if they agree. [bafybeigwwctpv37xdcwacqxvekr6e4kaemqsrv34em6glkbiceo3fcy4si](https://dweb.link/ipfs/bafybeigwwctpv37xdcwacqxvekr6e4kaemqsrv34em6glkbiceo3fcy4si)\"^
  },^
  \"terms\": {^
-  \"newFreeform\": {},^
-  \"closingTimestamp\": 1674678991^
+  \"newFreeform\": {}^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
@@ -8,7 +8,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
   \"description\": \"I propose that everyone evaluate the following IPFS document and vote Yes if they agree. [bafybeigwwctpv37xdcwacqxvekr6e4kaemqsrv34em6glkbiceo3fcy4si](https://dweb.link/ipfs/bafybeigwwctpv37xdcwacqxvekr6e4kaemqsrv34em6glkbiceo3fcy4si)\"^
  },^
  \"terms\": {^
-  \"newFreeform\": {}^
+  \"newFreeform\": {},^
+  \"closingTimestamp\": 1675103064000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
@@ -126,8 +126,8 @@
 
       // Optional new market meta data, tags
       metadata: [
-       "sector:energy",
-       "sector:materials",
+       "enactment:2023-01-31T17:58:46Z",
+       "settlement:2023-01-30T17:58:46Z",
        "source:docs.vega.xyz"
       ],
 
@@ -186,7 +186,7 @@
        r: 0.016,
 
        // Sigma parameter, annualised volatility of the underlying asset, must be a strictly non-negative real number (double as number) 
-       sigma: 0.3,
+       sigma: 0.5,
       }
      },
     }
@@ -194,11 +194,11 @@
 
    // Timestamp (Unix time in seconds) when voting closes for this proposal,
    // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-   closingTimestamp: 1674678991,
+   closingTimestamp: undefined,
 
    // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
    // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-   enactmentTimestamp: 1674765391,
+   enactmentTimestamp: undefined,
   }
  }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
@@ -126,8 +126,8 @@
 
       // Optional new market meta data, tags
       metadata: [
-       "enactment:2023-01-31T17:58:46Z",
-       "settlement:2023-01-30T17:58:46Z",
+       "enactment:2023-01-31T18:24:24Z",
+       "settlement:2023-01-30T18:24:24Z",
        "source:docs.vega.xyz"
       ],
 
@@ -194,11 +194,11 @@
 
    // Timestamp (Unix time in seconds) when voting closes for this proposal,
    // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-   closingTimestamp: undefined,
+   closingTimestamp: 1675103064000,
 
    // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
    // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-   enactmentTimestamp: undefined,
+   enactmentTimestamp: 1675189464000,
   }
  }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
@@ -77,8 +77,8 @@
       }
      },
      "metadata": [
-      "enactment:2023-01-31T17:58:46Z",
-      "settlement:2023-01-30T17:58:46Z",
+      "enactment:2023-01-31T18:24:24Z",
+      "settlement:2023-01-30T18:24:24Z",
       "source:docs.vega.xyz"
      ],
      "priceMonitoringParameters": {
@@ -108,7 +108,9 @@
       }
      }
     }
-   }
+   },
+   "closingTimestamp": 1675103064000,
+   "enactmentTimestamp": 1675189464000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
@@ -77,8 +77,8 @@
       }
      },
      "metadata": [
-      "sector:energy",
-      "sector:materials",
+      "enactment:2023-01-31T17:58:46Z",
+      "settlement:2023-01-30T17:58:46Z",
       "source:docs.vega.xyz"
      ],
      "priceMonitoringParameters": {
@@ -104,13 +104,11 @@
       "params": {
        "mu": 0,
        "r": 0.016,
-       "sigma": 0.3
+       "sigma": 0.5
       }
      }
     }
-   },
-   "closingTimestamp": 1674678991,
-   "enactmentTimestamp": 1674765391
+   }
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
@@ -76,8 +76,8 @@
           }
         },
         "metadata": [
-          "enactment:2023-01-31T17:58:46Z",
-          "settlement:2023-01-30T17:58:46Z",
+          "enactment:2023-01-31T18:24:24Z",
+          "settlement:2023-01-30T18:24:24Z",
           "source:docs.vega.xyz"
         ],
         "priceMonitoringParameters": {
@@ -107,7 +107,9 @@
           }
         }
       }
-    }
+    },
+    "closingTimestamp": 1675103064000,
+    "enactmentTimestamp": 1675189464000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
@@ -76,8 +76,8 @@
           }
         },
         "metadata": [
-          "sector:energy",
-          "sector:materials",
+          "enactment:2023-01-31T17:58:46Z",
+          "settlement:2023-01-30T17:58:46Z",
           "source:docs.vega.xyz"
         ],
         "priceMonitoringParameters": {
@@ -103,13 +103,11 @@
           "params": {
             "mu": 0,
             "r": 0.016,
-            "sigma": 0.3
+            "sigma": 0.5
           }
         }
       }
-    },
-    "closingTimestamp": 1674678991,
-    "enactmentTimestamp": 1674765391
+    }
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
@@ -28,10 +28,10 @@
   },
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: undefined,
+  closingTimestamp: 1675103064000,
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: undefined,
+  enactmentTimestamp: 1675189464000,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
@@ -28,10 +28,10 @@
   },
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1674678991,
+  closingTimestamp: undefined,
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1674765391,
+  enactmentTimestamp: undefined,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
@@ -78,8 +78,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
      }^
     },^
     \"metadata\": [^
-     \"enactment:2023-01-31T17:58:46Z\",^
-     \"settlement:2023-01-30T17:58:46Z\",^
+     \"enactment:2023-01-31T18:24:24Z\",^
+     \"settlement:2023-01-30T18:24:24Z\",^
      \"source:docs.vega.xyz\"^
     ],^
     \"priceMonitoringParameters\": {^
@@ -109,7 +109,9 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
      }^
     }^
    }^
-  }^
+  },^
+  \"closingTimestamp\": 1675103064000,^
+  \"enactmentTimestamp\": 1675189464000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
@@ -78,8 +78,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
      }^
     },^
     \"metadata\": [^
-     \"sector:energy\",^
-     \"sector:materials\",^
+     \"enactment:2023-01-31T17:58:46Z\",^
+     \"settlement:2023-01-30T17:58:46Z\",^
      \"source:docs.vega.xyz\"^
     ],^
     \"priceMonitoringParameters\": {^
@@ -105,13 +105,11 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
-      \"sigma\": 0.3^
+      \"sigma\": 0.5^
      }^
     }^
    }^
-  },^
-  \"closingTimestamp\": 1674678991,^
-  \"enactmentTimestamp\": 1674765391^
+  }^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
@@ -26,11 +26,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: undefined,
+  closingTimestamp: 1675103064000,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: undefined,
+  enactmentTimestamp: 1675189464000,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
@@ -26,11 +26,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1674678991,
+  closingTimestamp: undefined,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1674765391,
+  enactmentTimestamp: undefined,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
@@ -16,9 +16,7 @@
       "lifetimeLimit": "10"
      }
     }
-   },
-   "closingTimestamp": 1674678991,
-   "enactmentTimestamp": 1674765391
+   }
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
@@ -16,7 +16,9 @@
       "lifetimeLimit": "10"
      }
     }
-   }
+   },
+   "closingTimestamp": 1675103064000,
+   "enactmentTimestamp": 1675189464000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
@@ -15,9 +15,7 @@
           "lifetimeLimit": "10"
         }
       }
-    },
-    "closingTimestamp": 1674678991,
-    "enactmentTimestamp": 1674765391
+    }
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
@@ -15,7 +15,9 @@
           "lifetimeLimit": "10"
         }
       }
-    }
+    },
+    "closingTimestamp": 1675103064000,
+    "enactmentTimestamp": 1675189464000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
@@ -17,7 +17,9 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
      \"lifetimeLimit\": \"10\"^
     }^
    }^
-  }^
+  },^
+  \"closingTimestamp\": 1675103064000,^
+  \"enactmentTimestamp\": 1675189464000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
@@ -17,9 +17,7 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
      \"lifetimeLimit\": \"10\"^
     }^
    }^
-  },^
-  \"closingTimestamp\": 1674678991,^
-  \"enactmentTimestamp\": 1674765391^
+  }^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
@@ -17,7 +17,7 @@
     // Updated market instrument configuration
     instrument: {
      // Instrument code, human-readable shortcode used to describe the instrument
-     code: "ORANGES.24h",
+     code: "APPLES.22",
 
      // Future
      future: {
@@ -116,8 +116,6 @@
 
       // Optional market metadata, tags
       metadata: [
-       "sector:food",
-       "sector:health",
        "source:docs.vega.xyz"
       ],
 
@@ -157,7 +155,7 @@
         r: 0.016,
 
         // Sigma parameter, annualised volatility of the underlying asset, must be a strictly non-negative real number (double as number) 
-        sigma: 0.8,
+        sigma: 0.5,
        }
       },
      },
@@ -165,11 +163,11 @@
 
     // Timestamp (Unix time in seconds) when voting closes for this proposal,
     // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-    closingTimestamp: 1674678991,
+    closingTimestamp: undefined,
 
     // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
     // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-    enactmentTimestamp: 1674765391,
+    enactmentTimestamp: undefined,
    }
   }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
@@ -155,7 +155,7 @@
         r: 0.016,
 
         // Sigma parameter, annualised volatility of the underlying asset, must be a strictly non-negative real number (double as number) 
-        sigma: 0.5,
+        sigma: 1.25,
        }
       },
      },
@@ -163,11 +163,11 @@
 
     // Timestamp (Unix time in seconds) when voting closes for this proposal,
     // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-    closingTimestamp: undefined,
+    closingTimestamp: 1675103064000,
 
     // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
     // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-    enactmentTimestamp: undefined,
+    enactmentTimestamp: 1675189464000,
    }
   }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
@@ -12,7 +12,7 @@
     "changes": {
      "lpPriceRange": "11",
      "instrument": {
-      "code": "ORANGES.24h",
+      "code": "APPLES.22",
       "future": {
        "quoteName": "tEuro",
        "dataSourceSpecForSettlementData": {
@@ -74,8 +74,6 @@
       }
      },
      "metadata": [
-      "sector:food",
-      "sector:health",
       "source:docs.vega.xyz"
      ],
      "priceMonitoringParameters": {
@@ -93,13 +91,11 @@
       "params": {
        "mu": 0,
        "r": 0.016,
-       "sigma": 0.8
+       "sigma": 0.5
       }
      }
     }
-   },
-   "closingTimestamp": 1674678991,
-   "enactmentTimestamp": 1674765391
+   }
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
@@ -91,11 +91,13 @@
       "params": {
        "mu": 0,
        "r": 0.016,
-       "sigma": 0.5
+       "sigma": 1.25
       }
      }
     }
-   }
+   },
+   "closingTimestamp": 1675103064000,
+   "enactmentTimestamp": 1675189464000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
@@ -11,7 +11,7 @@
       "changes": {
         "lpPriceRange": "11",
         "instrument": {
-          "code": "ORANGES.24h",
+          "code": "APPLES.22",
           "future": {
             "quoteName": "tEuro",
             "dataSourceSpecForSettlementData": {
@@ -73,8 +73,6 @@
           }
         },
         "metadata": [
-          "sector:food",
-          "sector:health",
           "source:docs.vega.xyz"
         ],
         "priceMonitoringParameters": {
@@ -92,13 +90,11 @@
           "params": {
             "mu": 0,
             "r": 0.016,
-            "sigma": 0.8
+            "sigma": 0.5
           }
         }
       }
-    },
-    "closingTimestamp": 1674678991,
-    "enactmentTimestamp": 1674765391
+    }
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
@@ -90,11 +90,13 @@
           "params": {
             "mu": 0,
             "r": 0.016,
-            "sigma": 0.5
+            "sigma": 1.25
           }
         }
       }
-    }
+    },
+    "closingTimestamp": 1675103064000,
+    "enactmentTimestamp": 1675189464000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
@@ -92,11 +92,13 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
-      \"sigma\": 0.5^
+      \"sigma\": 1.25^
      }^
     }^
    }^
-  }^
+  },^
+  \"closingTimestamp\": 1675103064000,^
+  \"enactmentTimestamp\": 1675189464000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
@@ -13,7 +13,7 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
    \"changes\": {^
     \"lpPriceRange\": \"11\",^
     \"instrument\": {^
-     \"code\": \"ORANGES.24h\",^
+     \"code\": \"APPLES.22\",^
      \"future\": {^
       \"quoteName\": \"tEuro\",^
       \"dataSourceSpecForSettlementData\": {^
@@ -75,8 +75,6 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
      }^
     },^
     \"metadata\": [^
-     \"sector:food\",^
-     \"sector:health\",^
      \"source:docs.vega.xyz\"^
     ],^
     \"priceMonitoringParameters\": {^
@@ -94,13 +92,11 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
-      \"sigma\": 0.8^
+      \"sigma\": 0.5^
      }^
     }^
    }^
-  },^
-  \"closingTimestamp\": 1674678991,^
-  \"enactmentTimestamp\": 1674765391^
+  }^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
@@ -18,11 +18,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: undefined,
+  closingTimestamp: 1675103064000,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: undefined,
+  enactmentTimestamp: 1675189464000,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
@@ -18,11 +18,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1674678991,
+  closingTimestamp: undefined,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1674765391,
+  enactmentTimestamp: undefined,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
@@ -12,7 +12,9 @@
      "key": "market.fee.factors.infrastructureFee",
      "value": "300"
     }
-   }
+   },
+   "closingTimestamp": 1675103064000,
+   "enactmentTimestamp": 1675189464000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
@@ -12,9 +12,7 @@
      "key": "market.fee.factors.infrastructureFee",
      "value": "300"
     }
-   },
-   "closingTimestamp": 1674678991,
-   "enactmentTimestamp": 1674765391
+   }
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
@@ -11,7 +11,9 @@
         "key": "market.fee.factors.infrastructureFee",
         "value": "300"
       }
-    }
+    },
+    "closingTimestamp": 1675103064000,
+    "enactmentTimestamp": 1675189464000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
@@ -11,9 +11,7 @@
         "key": "market.fee.factors.infrastructureFee",
         "value": "300"
       }
-    },
-    "closingTimestamp": 1674678991,
-    "enactmentTimestamp": 1674765391
+    }
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
@@ -13,9 +13,7 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     \"key\": \"market.fee.factors.infrastructureFee\",^
     \"value\": \"300\"^
    }^
-  },^
-  \"closingTimestamp\": 1674678991,^
-  \"enactmentTimestamp\": 1674765391^
+  }^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
@@ -13,7 +13,9 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     \"key\": \"market.fee.factors.infrastructureFee\",^
     \"value\": \"300\"^
    }^
-  }^
+  },^
+  \"closingTimestamp\": 1675103064000,^
+  \"enactmentTimestamp\": 1675189464000^
  }^
 }^
 }"

--- a/scripts/generate_proposals.js
+++ b/scripts/generate_proposals.js
@@ -118,13 +118,21 @@ function daysInTheFuture(daysToAdd) {
   return getUnixTime(d) * 1000
 }
 
-function newProposal(p, skeleton, type) {
+function newProposal(p, skeleton, type, partialProposal) {
   
   assert.ok(skeleton.properties.closingTimestamp)
   assert.ok(skeleton.properties.enactmentTimestamp)
 
   const proposal = p
-
+  proposal.terms.closingTimestamp = partialProposal.terms.closingTimestamp
+      
+  // Freeform proposals don't get enacted, so they can't have this
+  if (type !== 'newFreeform') {
+    proposal.terms.enactmentTimestamp = partialProposal.terms.enactmentTimestamp
+  }
+  if (type === 'newAsset') {
+    proposal.terms.validationTimestamp = partialProposal.terms.enactmentTimestamp
+  }  
   proposal.terms[inspect.custom] = addTermsAnnotator(
     skeleton,
     proposal.terms,
@@ -264,7 +272,7 @@ function parse(api) {
         // TODO move in to new Proposal so we can use dates in metadata
         const changes = ProposalGenerator.get(type)(proposalTypes[type], proposal)
         output(
-          newProposal(changes, api.definitions.vegaProposalTerms, type),
+          newProposal(changes, api.definitions.vegaProposalTerms, type, proposal),
           type
         )
       } else {

--- a/scripts/generate_proposals.js
+++ b/scripts/generate_proposals.js
@@ -112,30 +112,24 @@ function addTermsAnnotator(skeleton, terms, type) {
  * @returns string unix timestamp of the date in the future
  */
 function daysInTheFuture(daysToAdd) {
-  const d = addDays(Date.now(), daysToAdd)
-  return getUnixTime(d)
+  const date = Date.now()
+  const d = addDays(new Date(date), daysToAdd)
+  // Unix Timestamp nano
+  return getUnixTime(d) * 1000
 }
 
 function newProposal(p, skeleton, type) {
+  
   assert.ok(skeleton.properties.closingTimestamp)
   assert.ok(skeleton.properties.enactmentTimestamp)
 
   const proposal = p
-  proposal.terms.closingTimestamp = daysInTheFuture(19)
 
-  // Freeform proposals don't get enacted, so they can't have this
-  if (type !== 'newFreeform') {
-    proposal.terms.enactmentTimestamp = daysInTheFuture(20)
-  }
-  if (type === 'newAsset') {
-    proposal.terms.validationTimestamp = daysInTheFuture(18)
-  }
   proposal.terms[inspect.custom] = addTermsAnnotator(
     skeleton,
     proposal.terms,
-    type
-  )
-
+    type)
+  
   const formatOptions = {
     indent: ' '
   }
@@ -256,7 +250,19 @@ function parse(api) {
   const partials = Object.keys(proposalTypes).map((type) => {
     if (excludeUnimplementedTypes.indexOf(type) === -1) {
       if (ProposalGenerator.has(type)) {
-        const changes = ProposalGenerator.get(type)(proposalTypes[type])
+        const proposal = { terms: {} }
+        proposal.terms.closingTimestamp = daysInTheFuture(19)
+      
+        // Freeform proposals don't get enacted, so they can't have this
+        if (type !== 'newFreeform') {
+          proposal.terms.enactmentTimestamp = daysInTheFuture(20)
+        }
+        if (type === 'newAsset') {
+          proposal.terms.validationTimestamp = daysInTheFuture(18)
+        }
+            
+        // TODO move in to new Proposal so we can use dates in metadata
+        const changes = ProposalGenerator.get(type)(proposalTypes[type], proposal)
         output(
           newProposal(changes, api.definitions.vegaProposalTerms, type),
           type

--- a/scripts/libGenerateProposals/newAsset.js
+++ b/scripts/libGenerateProposals/newAsset.js
@@ -1,15 +1,12 @@
 const assert = require('assert').strict;
-const sample = require('lodash/sample');
 const { inspect } = require('util');
 
 // Seed data: Some asset names
 const assetNames = [
-    { name: 'tEuro', symbol: 'tEURO', contractAddress: '0x0158031158Bb4dF2AD02eAA31e8963E84EA978a4' },
-    { name: 'tDAI TEST', symbol: 'tDAI', contractAddress: '0x26223f9C67871CFcEa329975f7BC0C9cB8FBDb9b' },
-    { name: 'tUSDC TEST', symbol: 'tUSDC', contractAddress: '0xB404c51BBC10dcBE948077F18a4B8E553D160084' },
+    { name: 'tDAI TEST', symbol: 'tDAI', contractAddress: '0x26223f9C67871CFcEa329975f7BC0C9cB8FBDb9b' }
 ];
 
-function newAsset(skeleton) {
+function newAsset(skeleton, proposalSoFar) {
   assert.ok(skeleton.properties.changes);
   assert.ok(skeleton.properties.changes.properties.name);
   assert.ok(skeleton.properties.changes.properties.symbol);
@@ -19,7 +16,7 @@ function newAsset(skeleton) {
   assert.ok(skeleton.properties.changes.properties.erc20.properties.withdrawThreshold);
   assert.ok(skeleton.properties.changes.properties.erc20.properties.lifetimeLimit);
 
-  const asset = sample(assetNames);
+  const asset = assetNames[0]
   const result = {
     rationale: {
       title: `Add ${asset.name} (${asset.symbol})`,

--- a/scripts/libGenerateProposals/newFreeform.js
+++ b/scripts/libGenerateProposals/newFreeform.js
@@ -1,7 +1,7 @@
 const assert = require('assert').strict;
 const { inspect } = require('util');
 
-function newFreeform(skeleton) {
+function newFreeform(skeleton, proposalSoFar) {
   assert.ok(skeleton.title);
 
   const result = {

--- a/scripts/libGenerateProposals/updateAsset.js
+++ b/scripts/libGenerateProposals/updateAsset.js
@@ -1,7 +1,7 @@
 const assert = require("assert").strict;
 const { inspect } = require("util");
 
-function updateAsset(skeleton) {
+function updateAsset(skeleton, proposalSoFar) {
   assert.ok(skeleton.properties.changes);
   assert.ok(skeleton.properties.changes.properties.erc20);
   assert.ok(

--- a/scripts/libGenerateProposals/updateMarket.js
+++ b/scripts/libGenerateProposals/updateMarket.js
@@ -7,12 +7,8 @@ const { inspect } = require('util');
 
 // Seed data: Some inspirational instrument names and corresponding codes
 const instruments = [
-    { name: 'Apples Yearly (2022)', code: 'APPLES.22' },
-    { name: 'Oranges Daily', code: 'ORANGES.24h' }
+    { name: 'Apples Yearly (2022)', code: 'APPLES.22' }
 ];
-
-// Seed data: some example metadata for a market
-const metadata = ['sector:energy', 'sector:tech', 'sector:materials', 'sector:health', 'sector:food']
 
 // This is slightly smaller than the one in newMarket
 function generateInstrument(skeleton) {
@@ -99,7 +95,7 @@ function generatePriceMonitoringParameters(skeleton) {
 function generateMetadata(skeleton) {
   assert.equal(skeleton.type, 'array', 'Market metadata type used to be an array')
   assert.equal(skeleton.items.type, 'string', 'Market metadata type used to be an array of strings')
-  return [...sampleSize(metadata, random(1,3)) ,'source:docs.vega.xyz'] 
+  return ['source:docs.vega.xyz'] 
 }
 
 function generateRiskModel(skeleton, riskModelType) {
@@ -154,7 +150,7 @@ function generateRiskModel(skeleton, riskModelType) {
 
 }
 
-function updateMarket(skeleton) {
+function updateMarket(skeleton, proposalSoFar) {
   assert.ok(skeleton.properties.changes);
   assert.ok(skeleton.properties.changes.properties.instrument);
   assert.ok(skeleton.properties.changes.properties.lpPriceRange);

--- a/scripts/libGenerateProposals/updateNetworkParameter.js
+++ b/scripts/libGenerateProposals/updateNetworkParameter.js
@@ -3,9 +3,9 @@ const assert = require('assert').strict;
 const { inspect } = require('util');
 
 // Seed data: Some valid network parameters
-const networkParameters = ['market.fee.factors.infrastructureFee', 'governance.proposal.asset.requiredMajority', 'governance.proposal.freeform.minVoterBalance']
+const networkParameters = ['market.fee.factors.infrastructureFee']
 
-function updateNetworkParameter(skeleton) {
+function updateNetworkParameter(skeleton, proposalSoFar) {
   assert.ok(skeleton.properties.changes);
   assert.ok(skeleton.properties.changes.properties.key);
   assert.ok(skeleton.properties.changes.properties.value);


### PR DESCRIPTION
Adds dates as metadata on new proposal examples

- Removes randomise `sector:blah` metadata in all proposals
- Removes randomised risk parameter values in New Market proposals
- Add new `expiry:2023...` and `settlement:2023...` metadata in `newMarket`

@daunatv https://github.com/vegaprotocol/documentation/pull/451/files#diff-025bd8ecb7be8b5c1999c36bbd0bbd4cb2d139af1f201a9fef7a17c2915d7b34 is the specific addition you asked for in #393 - does that look alright?

Closes #393
