### PR TITLE
Wallet API v2 updated token guidance

### DIFF
--- a/docs/api/vega-wallet/v2-api/get-started.md
+++ b/docs/api/vega-wallet/v2-api/get-started.md
@@ -147,10 +147,10 @@ vegawallet service run --load-tokens --network testnet1
 ### Verify the service
 1. Verify the service is running with `GET /api/v2/health`
 2. If it is running, verify the service exposes the JSON-RPC methods using `GET /api/v2/methods`
-3. If it does expose the methods, you can start issuing request to the wallet software with `POST /api/v2/requests`
+3. If it does expose the methods, you can start issuing requests to the wallet software with `POST /api/v2/requests`
    a. Get the chain ID of the network the wallet is connected to, to show data from the same network using `client.get_chain_id`.
 
-### Issue request to the service
+### Issue a request to the service
 
 :::caution Origin header required 
 The service requires the Origin (or Referrer) HTTP header to be specified in the request. This is usually handled by the browser, so you may not have to do anything, but for software that does not use one of those headers, the request will be rejected.

--- a/docs/api/vega-wallet/v2-api/get-started.md
+++ b/docs/api/vega-wallet/v2-api/get-started.md
@@ -19,7 +19,7 @@ The **JSON-RPC API** and its endpoint **`/api/v2/requests`** is in the alpha pha
 * 🛝 **[API playground](./openrpc-api-playground)**: Try it out and explore the potential results and errors
 
 ## Software compatibility
-Vega Wallet API (v2)'s latest version was released in Vega software `v.0.63.1`. If you're interacting with a network on `v0.63.1` or newer, you'll need to have a wallet that supports the new API.
+Vega Wallet API (v2)'s latest version was released in Vega software `v.0.67`. If you're interacting with a network on `v0.67` or newer, you'll need to have a wallet that supports the new API.
 
 :::note New to JSON-RPC?
 Read the [JSON-RPC specification ↗](https://www.jsonrpc.org/specification) for the standards and conventions.
@@ -40,7 +40,9 @@ See the full set of methods that you can use in the **[Open RPC documentation](.
 The service requires the Origin (or Referrer) HTTP header to be specified in the request. This is usually handled by the browser, so you may not have to do anything, but for software that does not use one of those headers, the request will be rejected.
 :::
 
-Use `POST /api/v2/requests` to communicate with the wallet. The request body is a JSON-RPC 2.0 payload.
+Use `POST /api/v2/requests` to communicate with the wallet. The request body is a JSON-RPC 2.0 payload. 
+
+If you want to use a [long-living token](#generate-a-long-living-token), you'll need to specify it in the `Authorization` HTTP header with the scheme `VWT`. Example: `Authorization: VWT <TOKEN>`
 
 1. Get the ID for the chain the service is connected to. This allows your app to display the information related to the network that the service is connected to:
 
@@ -70,9 +72,6 @@ Use `POST /api/v2/requests` to communicate with the wallet. The request body is 
     {
       "jsonrpc": "2.0",
       "method": "client.list_keys",
-      "params": {
-        "token": "THE_TOKEN_FROM_THE_CONNECT_WALLET_CALL"
-      }
       "id": "request_3"
     }
 ```
@@ -84,7 +83,6 @@ Use `POST /api/v2/requests` to communicate with the wallet. The request body is 
       "jsonrpc": "2.0",
       "method": "client.send_transaction",
       "params": {
-         "token": "THE_TOKEN_FROM_THE_CONNECT_WALLET_CALL",
          "publicKey": "ONE_OF_THE_PUBLIC_KEY_FROM_THE_LIST_KEY_CALL",
          "sendingMode": "TYPE_SYNC",
          "transaction": {
@@ -104,9 +102,6 @@ Use `POST /api/v2/requests` to communicate with the wallet. The request body is 
     {
       "jsonrpc": "2.0",
       "method": "client.disconnect_wallet",
-      "params": {
-        "token": "THE_TOKEN_FROM_THE_CONNECT_WALLET_CALL"
-      }
       "id": "request_5"
     }
 ```
@@ -150,17 +145,14 @@ The service requires the Origin (or Referrer) HTTP header to be specified in the
 
 Use `POST /api/v2/requests` to communicate with the wallet. The request body is a JSON-RPC 2.0 payload.
 
-1. You don't need to connect. You can use the pre-generated, long-living token in place of the regular token.
+1. You don't need to connect. You can use the pre-generated, long-living token in place of the regular token. The token should be specified in the `Authorization` HTTP header with the scheme `VWT`. Example: `Authorization: VWT <TOKEN>`
 
-   Use the method below to get the public keys you have access to:
+Use the method below to get the public keys you have access to:
 
 ```
     {
       "jsonrpc": "2.0",
       "method": "client.list_keys",
-      "params": {
-        "token": "THE_LONG_LIVING_TOKEN"
-      }
       "id": "request_1"
     }
 ```
@@ -174,7 +166,6 @@ Use `POST /api/v2/requests` to communicate with the wallet. The request body is 
       "jsonrpc": "2.0",
       "method": "client.send_transaction",
       "params": {
-         "token": "THE_LONG_LIVING_TOKEN",
          "publicKey": "ONE_OF_THE_PUBLIC_KEY_FROM_THE_LIST_KEY_CALL",
          "sendingMode": "TYPE_SYNC",
          "transaction": {

--- a/docs/api/vega-wallet/v2-api/get-started.md
+++ b/docs/api/vega-wallet/v2-api/get-started.md
@@ -34,6 +34,19 @@ Read the [JSON-RPC specification ↗](https://www.jsonrpc.org/specification) for
 
 See the full set of methods that you can use in the **[Open RPC documentation](./openrpc)**.
 
+### Retrieve token
+You can retrieve a [long-living token](#generate-a-long-living-token) using the command-line, see instructions below. 
+
+For sessions (the `client.connect_wallet` workflow below), the token is returned through the Authorization HTTP header in the client.connect_wallet response. This allows you to use to following technique:
+
+```
+response = send_requests("client.connect_wallet")
+
+token = response.Header("Authorization")
+
+send_requests("client.list_keys", header("Authorization", token))
+```
+
 ### Issue request to the service
 
 :::caution Origin header required 
@@ -42,7 +55,7 @@ The service requires the Origin (or Referrer) HTTP header to be specified in the
 
 Use `POST /api/v2/requests` to communicate with the wallet. The request body is a JSON-RPC 2.0 payload. 
 
-If you want to use a [long-living token](#generate-a-long-living-token), you'll need to specify it in the `Authorization` HTTP header with the scheme `VWT`. Example: `Authorization: VWT <TOKEN>`
+If you want to use a token, you'll need to specify it in the `Authorization` HTTP header with the scheme `VWT`. Example: `Authorization: VWT <TOKEN>`
 
 1. Get the ID for the chain the service is connected to. This allows your app to display the information related to the network that the service is connected to:
 


### PR DESCRIPTION
If you're looking to try out the new wallet V2 token before it's released to testnet:
* Use the updated 'getting started' guide, in the [deploy preview](https://deploy-preview-453--vega-docusaurus.netlify.app/testnet/api/vega-wallet/v2-api/get-started).
* Refer to the develop-branch [API documentation playground](https://playground.open-rpc.org/?url=https://raw.githubusercontent.com/vegaprotocol/vega/develop/wallet/api/openrpc.json&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:examplesDropdown]=false)

**How to try it out**
1. Start the wallet service
On http://localhost:1789/api/v2/requests, send the following body:

```
{
 "jsonrpc": "2.0",
 "method": "client.connect_wallet",
 "id": "make-something-up"
}
```

2. Get the token back from the header `Authorization` in the response
On http://localhost:1789/api/v2/requests, set the Authorization header with the previous value and send the following body:
```
{
  "jsonrpc": "2.0",
  "method": "client.list_keys",
 "id": "make-something-up"
}
```

Closes #452