### PR TITLE
Wallet docs updates: antivirus note, topic stub 

### DIFF
--- a/docs/api/vega-wallet/index.md
+++ b/docs/api/vega-wallet/index.md
@@ -3,6 +3,11 @@ title: Intro to Vega Wallet APIs
 hide_title: false
 sidebar_position: 1
 ---
+
+import Topic from '/docs/topics/_topic-wallet.mdx'
+
+<Topic />
+
 Build on and integrate with the Vega Wallet service using the available APIs.
 
 ## V2 API
@@ -17,3 +22,6 @@ The **JSON-RPC API** and its endpoint **`/api/v2/requests`** is in the alpha pha
 The **REST API** is being deprecated and will only be supported until the JSON-RPC API is out of alpha. 
 
 See the [REST API for Vega Wallet](./vega-wallet/v1-api) documentation.
+
+## Wallet app guides 
+If you want to use the Vega Wallet CLI app directly, rather than through the API, explore the [wallet guides](../../tools/vega-wallet/cli-wallet/index.md). 

--- a/docs/api/vega-wallet/v2-api/get-started.md
+++ b/docs/api/vega-wallet/v2-api/get-started.md
@@ -3,6 +3,10 @@ title: Get started with API v2
 hide_title: false
 sidebar_position: 1 
 ---
+import Topic from '/docs/topics/_topic-wallet.mdx'
+
+<Topic />
+
 Vega Wallet supports a JSON-RPC API for integrating interfaces with the Vega Wallet service, to read keys, get transaction approval, and more.
 
 :::note Admin access

--- a/docs/api/vega-wallet/v2-api/index.md
+++ b/docs/api/vega-wallet/v2-api/index.md
@@ -3,5 +3,8 @@ title: Wallet API v2
 ---
 import DocCardList from '@theme/DocCardList';
 import {useCurrentSidebarCategory} from '@docusaurus/theme-common';
+import Topic from '/docs/topics/_topic-wallet.mdx'
+
+<Topic />
 
 <DocCardList items={useCurrentSidebarCategory().items}/>

--- a/docs/concepts/vega-wallet.md
+++ b/docs/concepts/vega-wallet.md
@@ -4,6 +4,9 @@ title: Wallets and keys
 vega_network: TESTNET
 hide_title: false
 ---
+import Topic from '/docs/topics/_topic-wallet.mdx'
+
+<Topic />
 
 Vega Wallet is an app that lets you manage wallets and cryptographic key pairs. Key pairs are used to sign and send transactions in a secure way. 
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -5,7 +5,6 @@ hide_title: false
 
 Vega provides several apps and tools to make it easier to interact with the protocol. 
 
-For restricted mainnet, those tools include:
 ### Vega Wallet
 Use **[Vega Wallet](./vega-wallet/index.md)** to connect to a network to associate tokens for staking, and to sign messages. Using the Vega Wallet ensures your keys will be completely disassociated from your personal identity, and Vega will have no way to connect them with you, unless you share your public key for any reason.
 

--- a/docs/tools/vega-wallet/cli-wallet/index.md
+++ b/docs/tools/vega-wallet/cli-wallet/index.md
@@ -2,6 +2,9 @@
 title: CLI Wallet
 hide_title: false
 ---
+import Topic from '/docs/topics/_topic-wallet.mdx'
+
+<Topic />
 
 The Vega Wallet is available to use as a command-line application.
 

--- a/docs/tools/vega-wallet/cli-wallet/latest/create-wallet.md
+++ b/docs/tools/vega-wallet/cli-wallet/latest/create-wallet.md
@@ -21,11 +21,6 @@ These instructions cover Vega Wallet version 0.67.3, which is compatible with Ve
 
 Note: If you are looking for instructions for connecting your hardware wallet to MetaMask, see [MetaMask's guide ↗](https://metamask.zendesk.com/hc/en-us/articles/360020394612-How-to-connect-a-Trezor-or-Ledger-Hardware-Wallet).
 
-## Command line guidance
-Use the following instructions in command line. Below, you'll see commands in the code blocks for each operating system. Copy those instructions and paste them into your command line interface.
-
-In your command line interface, you can view a list of available commands by running `./vegawallet -h` on MacOS and Linux, or `vegawallet -h` on Windows. Help is also available for every command, for example: `vegawallet create -h` will provide information about the `create` command.
-
 ## 1. Install and run Vega Wallet
 
 ### Download file
@@ -66,6 +61,14 @@ Download `vegawallet-linux-amd64.zip`
 </TabItem>
 </Tabs>
 :::
+
+#### Antivirus software
+If you are running antivirus software, you may need to 'allowlist' or 'whitelist' the Vega Wallet software, so that your antivirus provider doesn't quarantine the software and block you from using it.
+
+## Command line guidance
+Use the following instructions in command line. Below, you'll see commands in the code blocks for each operating system. Copy those instructions and paste them into your command line interface.
+
+In your command line interface, you can view a list of available commands by running `./vegawallet -h` on MacOS and Linux, or `vegawallet -h` on Windows. Help is also available for every command, for example: `vegawallet create -h` will provide information about the `create` command.
 
 :::info
 You'll need to run the commands from the directory you've saved the wallet file in. Use the command `pwd` to find out where your terminal is looking in the file system. Use the command `cd` and the path/to/wallet/directory to tell the command line where to find the file. 

--- a/docs/tools/vega-wallet/cli-wallet/latest/create-wallet.md
+++ b/docs/tools/vega-wallet/cli-wallet/latest/create-wallet.md
@@ -10,6 +10,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { NetworkConfigAddress, NetworkConfigAddressText } from '@site/src/components/NetworkConfigAddress';
 import CodeBlock from '@theme/CodeBlock';
+import Topic from '/docs/topics/_topic-wallet.mdx'
+
+<Topic />
 
 To download Vega Wallet and create your wallet, follow the step-by-step instructions below. 
 

--- a/docs/tools/vega-wallet/desktop-app/latest/getting-started.md
+++ b/docs/tools/vega-wallet/desktop-app/latest/getting-started.md
@@ -85,7 +85,7 @@ If you don't already have a Vega wallet, create a new wallet.
 2. Click on "Create new wallet" 
 3. Enter a wallet name of your choice, and a passphrase. 
 4. Your first keypair will be created for you. You can create more keys for that wallet but you only need one to start interacting with Vega. 
-5. Choose a Vega network to connect to: Click on the arrow in the bottom bar of the app. 
+5. Choose a Vega network to connect to: Click on the arrow in the bottom bar of the app. If you do not have any network configuration, you can use the .toml URLs in the [manage networks guide](../../cli-wallet/latest/guides/manage-networks#network-urls) to import a network.
 
 ## Restore wallet
 If your Vega wallet was created on a different device, or you lost access to it but have the recovery phrase, you can recover the wallet using that recovery phrase. 
@@ -94,7 +94,7 @@ If your Vega wallet was created on a different device, or you lost access to it 
 2. Click on "Use recovery phrase"
 3. Enter your recovery phrase, exactly in the order that it was first presented to you. 
 4. Identify if your wallet was version 1 or 2 by choosing the version number. 
-5. Choose a Vega network to connect to: Click on the arrow in the bottom bar of the app. 
+5. Choose a Vega network to connect to: Click on the arrow in the bottom bar of the app. If you do not have any network configuration, you can use the .toml URLs in the [manage networks guide](../../cli-wallet/latest/guides/manage-networks#network-urls) to import a network.
 
 ## Updating the app
 It's recommended that you keep the Vega Wallet app up-to-date, to take advantage of the latest features. 
@@ -131,7 +131,10 @@ You recover a wallet using your recovery phrase, and the public key you see does
 
 #### Possible solutions
 * Choose the alternate wallet version number alongside your recovery phrase. If you recovered and chose "version 2", then you should try using the same recovery phrase but choose "version 1".
-* Ensure that your recovery phrase includes the exact same words, in the exact same order, as they were provided to you when you first created your wallet. 
+* Ensure that your recovery phrase includes the exact same words, in the exact same order, as they were provided to you when you first created your wallet.
+
+## No networks available
+If you chose not to import the available networks when setting up the wallet app, you will need to import them manually. Use the .toml URLs in the [manage networks guide](../../cli-wallet/latest/guides/manage-networks#network-urls) to import a network.
 
 ### Reporting bugs
 **[Report on the feedback board](https://github.com/vegaprotocol/feedback/discussions/)**: If you discover a bug or are having problems with the Desktop Wallet app, report them on Vega's feedback board. 

--- a/docs/tools/vega-wallet/desktop-app/latest/getting-started.md
+++ b/docs/tools/vega-wallet/desktop-app/latest/getting-started.md
@@ -64,6 +64,9 @@ Download `vegawallet-desktop-linux-amd64.zip`
 </TabItem>
 </Tabs>
 
+#### Antivirus software
+If you are running antivirus software, you may need to ‘allowlist’ or ‘whitelist’ the Vega Wallet software, so that your antivirus provider doesn’t quarantine the software and block you from using it.
+
 #### 2. Extract the file
 Click on the compressed folder to get access to the app. 
 

--- a/docs/tools/vega-wallet/index.md
+++ b/docs/tools/vega-wallet/index.md
@@ -25,7 +25,7 @@ Use the **[command line app](./cli-wallet/index.md)** to do everything you can d
 * Build and send transactions
 
 ## Vega Wallet API
-Integrate with the [Vega Wallet API](../../../../docs/api/vega-wallet/v2-api/get-started.md) to build UIs or create other headless applications like bots or scripts.
+Integrate with the [Vega Wallet API](../../api/vega-wallet/v2-api/get-started.md) to build UIs or create other headless applications like bots or scripts.
 
 ## What is a wallet?
 **[Wallet concepts](../../concepts/vega-wallet.md)**: Read about how the Vega Wallet works and what the terms like 'wallet name' and 'recovery phrase' mean.

--- a/docs/tools/vega-wallet/index.md
+++ b/docs/tools/vega-wallet/index.md
@@ -2,9 +2,13 @@
 title: Vega Wallet
 hide_title: false
 ---
+import Topic from '/docs/topics/_topic-wallet.mdx'
+
+<Topic />
+
 A Vega Wallet is essential for interacting with Vega, whether it's for staking or trading. The Vega Wallet apps allow you to manage wallets and key pairs, deposit and withdraw assets, stake and sign transactions.
 
-You can interact with a Vega wallet and its keys through two different apps:
+You can interact with a Vega wallet and its keys through two different apps, or integrate using the API. 
 
 ## Vega Wallet desktop app
 The **[desktop wallet](./desktop-app/index.md)** provides a visual interface to: 
@@ -19,6 +23,9 @@ Use the **[command line app](./cli-wallet/index.md)** to do everything you can d
 * Customise key details 
 * Isolate keys
 * Build and send transactions
+
+## Vega Wallet API
+Integrate with the [Vega Wallet API](../../../../docs/api/vega-wallet/v2-api/get-started.md) to build UIs or create other headless applications like bots or scripts.
 
 ## What is a wallet?
 **[Wallet concepts](../../concepts/vega-wallet.md)**: Read about how the Vega Wallet works and what the terms like 'wallet name' and 'recovery phrase' mean.

--- a/docs/topics/_topic-wallet.mdx
+++ b/docs/topics/_topic-wallet.mdx
@@ -6,9 +6,9 @@ This section is part of a series on the topic of the *Vega Wallet*.
 Docs:
 
 - [What is Vega Wallet](/concepts/vega-wallet.md)
-- [Get the desktop app](/tools/vega-wallet/index.md)
-- [Get the CLI app](/tools/vega-wallet/cli-wallet/latest/create-wallet.md)
-- [Guides for the CLI app](/tools/vega-wallet/cli-wallet/latest/index.md)
+- [Get the desktop app](/tools/vega-wallet/desktop-app/latest/index.md)
+- [Create a wallet with the CLI app](/tools/vega-wallet/cli-wallet/latest/create-wallet.md)
+- [Guides for the CLI app](/tools/vega-wallet/cli-wallet/latest/guides/index.md)
 - [Using the Vega Wallet API](/api/vega-wallet/index.md)
 
 Other resources:

--- a/docs/topics/_topic-wallet.mdx
+++ b/docs/topics/_topic-wallet.mdx
@@ -1,5 +1,5 @@
 <div class="stub">
-<details><summary>Topic: Development</summary>
+<details><summary>Topic: Vega Wallet</summary>
 
 This section is part of a series on the topic of the *Vega Wallet*.
 

--- a/docs/topics/_topic-wallet.mdx
+++ b/docs/topics/_topic-wallet.mdx
@@ -6,10 +6,10 @@ This section is part of a series on the topic of the *Vega Wallet*.
 Docs:
 
 - [What is Vega Wallet](/concepts/vega-wallet.md)
-- [Get the desktop app](/tools/vega-wallet/desktop-app)
-- [Get the CLI app](/tools/vega-wallet/cli-wallet/latest/create-wallet)
-- [Guides for the CLI app](/tools/vega-wallet/cli-wallet/latest/guides)
-- [Using the Vega Wallet API](/api/vega-wallet)
+- [Get the desktop app](/tools/vega-wallet/index.md)
+- [Get the CLI app](/tools/vega-wallet/cli-wallet/latest/create-wallet.md)
+- [Guides for the CLI app](/tools/vega-wallet/cli-wallet/latest/index.md)
+- [Using the Vega Wallet API](/api/vega-wallet/index.md)
 
 Other resources:
 

--- a/docs/topics/_topic-wallet.mdx
+++ b/docs/topics/_topic-wallet.mdx
@@ -1,0 +1,19 @@
+<div class="stub">
+<details><summary>Topic: Development</summary>
+
+This section is part of a series on the topic of the *Vega Wallet*.
+
+Docs:
+
+- [What is Vega Wallet](/concepts/vega-wallet.md)
+- [Get the desktop app](/tools/vega-wallet/desktop-app)
+- [Get the CLI app](/tools/vega-wallet/cli-wallet/latest/create-wallet)
+- [Guides for the CLI app](/tools/vega-wallet/cli-wallet/latest/guides)
+- [Using the Vega Wallet API](/api/vega-wallet)
+
+Other resources:
+
+- [See the code on GitHub ↗](https://github.com/vegaprotocol/vega)
+
+</details>
+</div>

--- a/versioned_docs/version-v0.53/tools/vega-wallet/cli-wallet/latest/create-wallet.md
+++ b/versioned_docs/version-v0.53/tools/vega-wallet/cli-wallet/latest/create-wallet.md
@@ -24,7 +24,7 @@ The wallet software linked below is only compatible with the Vega mainnet networ
 
 **Download and save the zip file from [Vega Wallet software releases ↗](https://github.com/vegaprotocol/vegawallet/releases/)**. Keep track of where you've saved the file, because that's where the command line interface will look for it.
 
-:::note You may need to change your system preferences to run the file. 
+:::note You may need to change your system preferences to run the file.
 
 <Tabs groupId="operating-systems">
 <TabItem value="windows" label="Windows">

--- a/versioned_docs/version-v0.53/tools/vega-wallet/cli-wallet/latest/create-wallet.md
+++ b/versioned_docs/version-v0.53/tools/vega-wallet/cli-wallet/latest/create-wallet.md
@@ -18,11 +18,6 @@ Note: If you are looking for instructions for connecting your hardware wallet to
 The wallet software linked below is only compatible with the Vega mainnet network on v0.53. If you need a wallet for use with the Vega testnet, Fairground, see **[Create a wallet (testnet)](https://docs.vega.xyz/docs/testnet/tools/vega-wallet/cli-wallet/latest/create-wallet)**.
 :::
 
-## Command line guidance
-Use the following instructions in command line. Below, you'll see commands in the code blocks for each operating system. Copy those instructions and paste them into your command line interface.
-
-In your command line interface, you can view a list of available commands by running `./vegawallet -h` on MacOS and Linux, or `vegawallet -h` on Windows. Help is also available for every command, for example: `vegawallet create -h` will provide information about the `create` command.
-
 ## 1. Install and run Vega Wallet
 
 ### Download file
@@ -63,6 +58,15 @@ Download `vegawallet-linux-amd64.zip`
 </TabItem>
 </Tabs>
 :::
+
+#### Antivirus software
+If you are running antivirus software, you may need to 'allowlist' or 'whitelist' the Vega Wallet software, so that your antivirus provider doesn't quarantine the software and block you from using it.
+
+## Command line guidance
+Use the following instructions in command line. Below, you'll see commands in the code blocks for each operating system. Copy those instructions and paste them into your command line interface.
+
+In your command line interface, you can view a list of available commands by running `./vegawallet -h` on MacOS and Linux, or `vegawallet -h` on Windows. Help is also available for every command, for example: `vegawallet create -h` will provide information about the `create` command.
+
 
 :::info
 You'll need to run the commands from the directory you've saved the wallet file in. Use the command `pwd` to find out where your terminal is looking in the file system. Use the command `cd` and the path/to/wallet/directory to tell the command line where to find the file. 

--- a/versioned_docs/version-v0.53/tools/vega-wallet/desktop-app/latest/getting-started.md
+++ b/versioned_docs/version-v0.53/tools/vega-wallet/desktop-app/latest/getting-started.md
@@ -86,7 +86,7 @@ If you don't already have a Vega wallet, create a new wallet.
 2. Click on "Create new wallet" 
 3. Enter a wallet name of your choice, and a passphrase. 
 4. Your first keypair will be created for you. You can create more keys for that wallet but you only need one to start interacting with Vega. 
-5. Choose a Vega network to connect to: Click on the arrow in the bottom bar of the app. 
+5. Choose a Vega network to connect to: Click on the arrow in the bottom bar of the app. If you do not have any network configuration, you can use the .toml URLs in the [manage networks guide](../../cli-wallet/latest/guides/manage-networks#network-urls) to import a network.
 
 ## Restore wallet
 If your Vega wallet was created on a different device, or you lost access to it but have the recovery phrase, you can recover the wallet using that recovery phrase. 
@@ -95,7 +95,7 @@ If your Vega wallet was created on a different device, or you lost access to it 
 2. Click on "Use recovery phrase"
 3. Enter your recovery phrase, exactly in the order that it was first presented to you. 
 4. Identify if your wallet was version 1 or 2 by choosing the version number. 
-5. Choose a Vega network to connect to: Click on the arrow in the bottom bar of the app. 
+5. Choose a Vega network to connect to: Click on the arrow in the bottom bar of the app. If you do not have any network configuration, you can use the .toml URLs in the [manage networks guide](../../cli-wallet/latest/guides/manage-networks#network-urls) to import a network.
 
 ## Networks and nodes
 
@@ -153,6 +153,9 @@ You recover a wallet using your recovery phrase, and the public key you see does
 #### Possible solutions
 * Choose the alternate wallet version number alongside your recovery phrase. If you recovered and chose "version 2", then you should try using the same recovery phrase but choose "version 1". 
 * Ensure that your recovery phrase includes the exact same words, in the exact same order, as they were provided to you when you first created your wallet. 
+
+## No networks available
+If you chose not to import the available networks when setting up the wallet app, you will need to import them manually. Use the .toml URLs in the [manage networks guide](../../cli-wallet/latest/guides/manage-networks#network-urls) to import a network.
 
 ### Reporting bugs
 **[Report on the feedback board](https://github.com/vegaprotocol/feedback/discussions/)**: If you discover a bug or are having problems with the Desktop Wallet app, report them on Vega's feedback board. 

--- a/versioned_docs/version-v0.53/tools/vega-wallet/desktop-app/latest/getting-started.md
+++ b/versioned_docs/version-v0.53/tools/vega-wallet/desktop-app/latest/getting-started.md
@@ -65,6 +65,9 @@ Download `vegawallet-desktop-linux-amd64.zip`
 </TabItem>
 </Tabs>
 
+#### Antivirus software
+If you are running antivirus software, you may need to ‘allowlist’ or ‘whitelist’ the Vega Wallet software, so that your antivirus provider doesn’t quarantine the software and block you from using it.
+
 #### 2. Extract the file
 Click on the compressed folder to get access to the app. 
 

--- a/versioned_docs/version-v0.53/tools/vega-wallet/index.md
+++ b/versioned_docs/version-v0.53/tools/vega-wallet/index.md
@@ -5,7 +5,7 @@ hide_title: false
 
 Vega Wallet allows you to manage wallets and key pairs, and sign transactions.
 
-You can interact with a Vega wallet and its keys through two different apps:
+You can interact with a Vega wallet and its keys through two different apps.
 
 ## Vega Wallet desktop app
 The **[desktop wallet](./desktop-app/index.md)** provides a visual interface to: 


### PR DESCRIPTION
Closes #469 
Closes #471 
Also adds a wallet topic to link across between app guides, concepts & api docs; moves 'command line guidance' down the page on the cli wallet page