### PR TITLE
Add upgrading index to mainnet

### DIFF
--- a/docs/node-operators/get-started/setup-server.md
+++ b/docs/node-operators/get-started/setup-server.md
@@ -18,9 +18,11 @@ Both nodes are built using bare Go and should run on most mainstream platforms (
 The instructions below guide you on how to build from source code.
 
 :::tip Setting home folder
-The following commands use the `--home` flag, to allow you to specify a custom home for the configuration, state, and cache of your Vega node. Remove it to use the default path.
+The following commands use the `--home` flag, to allow you to specify a custom home for the configuration, state, and cache of your Vega node. Remove it to use the default path. 
 
- You can list all the paths used by your Vega installation with the following command:
+It's recommended that you use different folders for your Vega and Tendermint homes. Keep track of which home you're referring to as you progress.
+
+You can list all the paths used by your Vega installation with the following command:
 `vega paths list`
 :::
 

--- a/docs/node-operators/get-started/setup-validator.md
+++ b/docs/node-operators/get-started/setup-validator.md
@@ -12,7 +12,7 @@ This will also initiate the node wallet software, which you'll be prompted to cr
 
 First, generate the default configuration files for Vega and Tendermint. You can then alter those to the specific requirements.
 
-The below command will create home paths (if they don't already exist) and generate the configuration in the homes you chose. 
+The below command will create home paths (if they don't already exist) and generate the configuration in the homes you chose. **It's recommended that you use different folders for your Vega and Tendermint homes. Keep track of which home you're referring to as you progress.**
 
 ```
 vega init --home=YOUR_VEGA_HOME_PATH --tendermint-home=YOUR_TENDERMINT_HOME_PATH validator

--- a/docs/node-operators/get-started/setup-validator.md
+++ b/docs/node-operators/get-started/setup-validator.md
@@ -120,16 +120,16 @@ Use that address in your node's Vega config `YOUR_VEGA_HOME_PATH/config/node/con
 
 
 ### Point to Ethereum node
-In order to validate events happening on the Ethereum bridge, the Vega node needs to be connected to an Ethereum archive node (rather than full node). The core software connects to the `eth_getLogs` endpoint, which is only available on archive nodes. This allows the Vega node to verify that an event happened on Ethereum (e.g: a deposit or a withdrawal).
+In order to validate events happening on the Ethereum bridge, each Vega validator node needs to be connected to an **Ethereum archive node** (not a full node). The core software connects to the `eth_getLogs` endpoint, which is only available on archive nodes. This allows the Vega node to verify that an event happened on Ethereum (e.g: a deposit or a withdrawal).
 
-The Ethereum node address for the RPC endpoint needs to be set up in the configuration. 
+The Ethereum node address for the RPC endpoint is set in the configuration. 
 
 Once you have an Ethereum archive node, insert the URL in `YOUR_VEGA_HOME/config/node/config.toml`, in the section:
 
 ```toml
 [Ethereum]
     Level = "Info"
-    RPCEndpoint = "INSERT_URL_HERE"
+    RPCEndpoint = "INSERT_ARCHIVE_NODE_URL_HERE"
     RetryDelay = "15s"
 ```
 

--- a/docs/node-operators/how-to/restart-network.md
+++ b/docs/node-operators/how-to/restart-network.md
@@ -126,7 +126,13 @@ You can locate all your nodes' checkpoint files under: `YOUR_VEGA_HOME/vega/node
 You can also get a list of all paths used by your node using `vega paths list`. The checkpoints folder path is `CheckpointStateHome` within this list.
 :::
 
-You can now remove all previous states of the chain by running:
+You can now remove all previous states of the chain by running the reset commands separately or together.
+
+:::caution Reset clears all data
+Ensure that your Vega and Tendermint config homes are different, as this command will delete everything within the home folder. If, for example, you reset Tendermint and everything is in the same folder or choose the Vega home path rather than Tendermint, it will also delete your Vega config and saved keys.
+:::
+
+
 ```
 vega unsafe_reset_all --home="YOUR_VEGA_HOME"
 vega tm unsafe_reset_all --home="YOUR_TENDERMINT_HOME"

--- a/docs/node-operators/how-to/use-snapshots.md
+++ b/docs/node-operators/how-to/use-snapshots.md
@@ -93,7 +93,14 @@ Once you update the Tendermint config, restart the node by running:
 ```
 vega start --home="YOUR_VEGA_HOME" --tendermint-home="YOUR_TENDERMINT_HOME" --network-url="NETWORK_URL"
 ```
-If you need to reset the Tendermint and Vega nodes, use the following commands. They will remove all chain-related data and keep node wallets, private keys and saved config:
+If you need to reset the Tendermint and Vega nodes, use the following commands. They will remove all chain-related data and keep node wallets, private keys and saved config. 
+
+You can now remove all previous states of the chain by running the reset commands, either together or separately.
+
+:::caution Reset clears all data
+Ensure that your Vega and Tendermint config homes are different, as this command will delete everything within the home folder. If, for example, you reset Tendermint and everything is in the same folder or choose the Vega home path rather than Tendermint, it will also delete your Vega config and saved keys.
+:::
+
 
 ```
 vega tendermint unsafe_reset_all --home="YOUR_TENDERMINT_HOME"

--- a/versioned_docs/version-v0.53/node-operators/migration-guides/upgrade-from-053-to-067.md
+++ b/versioned_docs/version-v0.53/node-operators/migration-guides/upgrade-from-053-to-067.md
@@ -1,0 +1,16 @@
+---
+title: Upgrading from 0.53
+sidebar_label: Upgrading from 0.53
+sidebar_position: 1
+---
+
+Before upgrading your node software from version 0.53 to 0.67, read the upgrading file in the Vega repo for a full list of the changes between the two versions, and review the breaking API changes.
+
+The **[testnet release notes](https://docs.vega.xyz/testnet/releases/overview)** have a list of breaking API changes for each version from 0.54 onwards.
+
+The **[upgrading readme ↗](https://github.com/vegaprotocol/vega/blob/develop/UPGRADING.md)** has details on major updates including:
+
+* [Repository changes ↗](https://github.com/vegaprotocol/vega/blob/develop/UPGRADING.md#repository-changes)
+* [Configuration changes ↗](https://github.com/vegaprotocol/vega/blob/develop/UPGRADING.md#configuration-changes)
+* [Command line changes ↗](https://github.com/vegaprotocol/vega/blob/develop/UPGRADING.md#command-line-changes)
+

--- a/versioned_docs/version-v0.53/node-operators/network-restarts.md
+++ b/versioned_docs/version-v0.53/node-operators/network-restarts.md
@@ -126,7 +126,13 @@ You can locate all your nodes' checkpoint files under: `/YOUR_VEGA_HOME/vega/nod
 You can also get a list of all paths used by your node using `vega paths list`. The checkpoints folder path is `CheckpointStateHome` within this list.
 :::
 
-You can now remove all previous states of the chain by running:
+You can now remove all previous states of the chain by running the reset commands, either together or separately.
+
+:::caution Reset clears all data
+Ensure that your Vega and Tendermint config homes are different, as this command will delete everything within the home folder. If, for example, you reset Tendermint and everything is in the same folder or choose the Vega home path rather than Tendermint, it will also delete your Vega config and saved keys.
+:::
+
+
 ```
 vega unsafe_reset_all --home="YOUR_VEGA_HOME_PATH"
 vega tm unsafe_reset_all --home="YOUR_TENDERMINT_HOME_PATH"

--- a/versioned_docs/version-v0.53/node-operators/setup-validator.md
+++ b/versioned_docs/version-v0.53/node-operators/setup-validator.md
@@ -14,6 +14,8 @@ This section will take your through all the steps to configure your node as a va
 :::note
 All the following commands will use an optional `--home` flag. This flag allows you to specify a custom home for the configuration, state, and cache of your Vega node. The flag is not mandatory and a default path will be chosen if not specified. 
 
+It's recommended that you use different folders for your Vega and Tendermint homes. Keep track of which home you're referring to as you progress.
+
 The XDG Base Directory standard is use to create the path, see: [XDG Base Directory spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 
 :::


### PR DESCRIPTION
Adds the existing upgrading index of links to the mainnet side so it's available on both testnet & mainnet docs for node operators 

Also improves guidance for the home paths to nudge people away from mixing them up