### PR TITLE
Add links to mainnet incident reports

### DIFF
--- a/docs/concepts/new-to-vega.md
+++ b/docs/concepts/new-to-vega.md
@@ -30,7 +30,9 @@ Restricted mainnet is the first decentralised version of the Vega network. The f
 
 Although restricted mainnet is a live, decentralised network that allows tokenholders to interact with it, it is also an **extended test phase**. 
 
-Its functionality is limited and is riskier than networks that will follow it, and involves regularly scheduled software upgrades and downtime. There will probably be some growing pains as the network is stress-tested and upgrades are rolled out.  
+Its functionality is limited and is riskier than networks that will follow it, and involves regularly scheduled software upgrades and downtime. There will probably be some growing pains as the network is stress-tested and upgrades are rolled out.
+
+**[Mainnet incidents](https://blog.vega.xyz/tagged/vega-incident-reports)**: Vega publishes information about mainnet incidents and their resolutions on the blog.
 
 ## How can I use Vega?
 
@@ -48,5 +50,4 @@ Its functionality is limited and is riskier than networks that will follow it, a
 
 ## How can I contribute to Vega?
 * [Bugs and feature requests](https://github.com/vegaprotocol/feedback/discussions/): Raise any bugs you find, or feature requests you have, on Vega's feedback board.
-* [Developer bounties](https://github.com/vegaprotocol/bounties/): See available bounties on the bounties repo. 
 * [Documentation translation](https://github.com/vegaprotocol/documentation/issues): Raise an issue on the documentation repo to express your interest in translating Vega documentation. 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -90,12 +90,12 @@ module.exports = {
               to: "https://github.com/vegaprotocol",
             },
             {
-              label: "Blog",
-              to: "https://blog.vega.xyz",
+              label: "Mainnet incidents",
+              to: "https://blog.vega.xyz/tagged/vega-incident-reports",
             },
             {
-              label: "Twitch",
-              to: "https://www.twitch.tv/vegaprotocol",
+              label: "Blog",
+              to: "https://blog.vega.xyz",
             },
             {
               label: "YouTube",
@@ -121,6 +121,10 @@ module.exports = {
             {
               label: "Telegram",
               to: "https://t.me/vegacommunity",
+            },
+            {
+              label: "Twitch",
+              to: "https://www.twitch.tv/vegaprotocol",
             },
           ],
         },

--- a/versioned_docs/version-v0.53/concepts/new-to-vega.md
+++ b/versioned_docs/version-v0.53/concepts/new-to-vega.md
@@ -30,7 +30,9 @@ Restricted mainnet is the first decentralised version of the Vega network. The f
 
 Although restricted mainnet is a live, decentralised network that allows tokenholders to interact with it, it is also an **extended test phase**. 
 
-Its functionality is limited and is riskier than networks that will follow it, and involves regularly scheduled software upgrades and downtime. There will probably some growing pains as the network is stress-tested and upgrades are rolled out.  
+Its functionality is limited and is riskier than networks that will follow it, and involves regularly scheduled software upgrades and downtime. There will probably some growing pains as the network is stress-tested and upgrades are rolled out.
+
+**[Mainnet incidents](https://blog.vega.xyz/tagged/vega-incident-reports)**: Vega publishes information about mainnet incidents and their resolutions on the blog.
 
 ## How can I use Vega?
 
@@ -40,7 +42,7 @@ Its functionality is limited and is riskier than networks that will follow it, a
 #### Token management and network governance 
 * [Mainnet token interface](https://token.vega.xyz): Interact with your $VEGA tokens on the token interface.
 * [Mainnet FAQ](https://blog.vega.xyz/the-vega-restricted-mainnet-faqs-6bedc7a57f24): Regularly updated list of the most commonly asked questions and answers to help you get your bearings with restricted mainnet.
-* [Fairground token interface](https://token.fairground.wtf): You can also try out the interface using testnet tokens, if you want to familiarise yourself with it first.
+* [Fairground governance interface](https://token.fairground.wtf): You can also try out the interface using testnet tokens, if you want to familiarise yourself with it first.
 
 #### Fairground, Vega's testnet
 * [Learn about Fairground](https://fairground.wtf): Though trading isn't enabled on mainnet, you can try trading on Fairground. Place an order, track your positions, and explore the margin mechanism using Fairground. Keep an eye on the site for incentive opportunties, too. 
@@ -48,5 +50,4 @@ Its functionality is limited and is riskier than networks that will follow it, a
 
 ## How can I contribute to Vega?
 * [Bugs and feature requests](https://github.com/vegaprotocol/feedback/discussions/): Raise any bugs you find, or feature requests you have, on Vega's feedback board.
-* [Developer bounties](https://github.com/vegaprotocol/bounties/): See available bounties on the bounties repo. 
 * [Documentation translation](https://github.com/vegaprotocol/documentation/issues): Raise an issue on the documentation repo to express your interest in translating Vega documentation. 


### PR DESCRIPTION
Closes #472 Also removes bounties repo link (not maintained).