### PR TITLE
fix: stubs have double lines in expandy bit

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -277,10 +277,11 @@ a.external:after {
     text-decoration-color: var(--ifm-color-secondary-darkest);
 }
 
-/* Very specific styles to eliminate some */
-.col--12 .stub details div.collapsibleContent_node_modules-\@docusaurus-theme-common-lib-components-Details-styles-module {
+/* Very specific styles to eliminate some double lines
+  'Class starts with' selector used because the name changes in build */
+.col--12 .stub details div[class^='collapsibleContent_'] {
   border-top: none !important;
-  margin-top: none !important;
+  margin-top: 0px !important;
   padding-top: 0; 
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -277,6 +277,13 @@ a.external:after {
     text-decoration-color: var(--ifm-color-secondary-darkest);
 }
 
+/* Very specific styles to eliminate some */
+.col--12 .stub details div.collapsibleContent_node_modules-\@docusaurus-theme-common-lib-components-Details-styles-module {
+  border-top: none !important;
+  margin-top: none !important;
+  padding-top: 0; 
+}
+
 /* OpenAPI docs */
 /* Sidebar Method labels */
 .api-method > .menu__link {


### PR DESCRIPTION
# Before
<img width="997" alt="Screenshot 2023-02-28 at 10 50 49" src="https://user-images.githubusercontent.com/6678/221833080-e374790c-0d4e-4da1-b187-a33fd6925001.png">

# After
<img width="983" alt="Screenshot 2023-02-28 at 10 50 20" src="https://user-images.githubusercontent.com/6678/221833075-0ddcaf25-b590-417b-bd03-92ad167151f4.png">

# Cause

Unsatisfyingly: I'm not sure. A theme update perhaps?
