### PR TITLE
Validator testnet URLs

### DIFF
--- a/docs/api/public-endpoints.md
+++ b/docs/api/public-endpoints.md
@@ -1,0 +1,24 @@
+---
+title: Public endpoints
+hide_title: false
+description: Vega's APIs are served over public endpoints.
+vega_network: TESTNET
+---
+
+import Topic from '/docs/topics/_topic-development.mdx'
+import DataNodes from '@site/src/components/DataNodes';
+
+Due to the distributed nature of Vega, most of the APIs are served from a data node, and a few from a core node. This means there is no single API server, and users will need to choose a node to connect to.
+
+This differs from centralised services, as you can't connect to an API server run by a single company, nor does it require a specific access token. 
+
+Below, find a list of all the public endpoints available for the Vega-run testnet (fairground), and the validator-run testnet. 
+
+:::note Read more
+[Data nodes](../concepts/vega-chain/data-nodes.md): Find out what a data node is, and if setting one up for yourself is right for you.
+:::
+
+## Node API endpoints: Fairground
+<DataNodes frontMatter={frontMatter} />
+
+## Node API endpoints: Validator testnet

--- a/versioned_docs/version-v0.53/api/public-endpoints.md
+++ b/versioned_docs/version-v0.53/api/public-endpoints.md
@@ -1,0 +1,18 @@
+---
+title: Public endpoints
+hide_title: false
+description: Vega's APIs are served over public endpoints.
+vega_network: MAINNET
+---
+import Topic from '/docs/topics/_topic-development.mdx'
+import DataNodes from '@site/src/components/DataNodes';
+
+Due to the distributed nature of Vega, most of the APIs are served from a data node, and a few from a core node. This means there is no single API server, and users will need to choose a node to connect to.
+
+This differs from centralised services, as you can't connect to an API server run by a single company, nor does it require a specific access token. 
+
+Below, find a list of all the public endpoints available for this network. 
+
+## Node API endpoints
+<DataNodes frontMatter={frontMatter} />
+


### PR DESCRIPTION
Closes #477 
Still in draft as the current URLs are extremely likely to change. This PR adds a public endpoints page with existing API connection URLs, and the new ones for the validator testnet.