### PR TITLE
Fix example new market proposal to have correct oracle

### DIFF
--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
@@ -38,14 +38,14 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1681727444000,
+  closingTimestamp: 1682350957000,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1681813844000,
+  enactmentTimestamp: 1682437357000,
 
   // Validation timestamp (Unix time in seconds) (int64 as string)
-  validationTimestamp: 1681813844000
+  validationTimestamp: 1682437357000
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
@@ -38,14 +38,14 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1682350957000,
+  closingTimestamp: 1682435906000,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1682437357000,
+  enactmentTimestamp: 1682522306000,
 
   // Validation timestamp (Unix time in seconds) (int64 as string)
-  validationTimestamp: 1682437357000
+  validationTimestamp: 1682522306000
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
@@ -20,9 +20,9 @@
      }
     }
    },
-   "closingTimestamp": 1682350957000,
-   "enactmentTimestamp": 1682437357000,
-   "validationTimestamp": 1682437357000
+   "closingTimestamp": 1682435906000,
+   "enactmentTimestamp": 1682522306000,
+   "validationTimestamp": 1682522306000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
@@ -20,9 +20,9 @@
      }
     }
    },
-   "closingTimestamp": 1681727444000,
-   "enactmentTimestamp": 1681813844000,
-   "validationTimestamp": 1681813844000
+   "closingTimestamp": 1682350957000,
+   "enactmentTimestamp": 1682437357000,
+   "validationTimestamp": 1682437357000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
@@ -19,9 +19,9 @@
         }
       }
     },
-    "closingTimestamp": 1681727444000,
-    "enactmentTimestamp": 1681813844000,
-    "validationTimestamp": 1681813844000
+    "closingTimestamp": 1682350957000,
+    "enactmentTimestamp": 1682437357000,
+    "validationTimestamp": 1682437357000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
@@ -19,9 +19,9 @@
         }
       }
     },
-    "closingTimestamp": 1682350957000,
-    "enactmentTimestamp": 1682437357000,
-    "validationTimestamp": 1682437357000
+    "closingTimestamp": 1682435906000,
+    "enactmentTimestamp": 1682522306000,
+    "validationTimestamp": 1682522306000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
@@ -21,9 +21,9 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     }^
    }^
   },^
-  \"closingTimestamp\": 1681727444000,^
-  \"enactmentTimestamp\": 1681813844000,^
-  \"validationTimestamp\": 1681813844000^
+  \"closingTimestamp\": 1682350957000,^
+  \"enactmentTimestamp\": 1682437357000,^
+  \"validationTimestamp\": 1682437357000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
@@ -21,9 +21,9 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     }^
    }^
   },^
-  \"closingTimestamp\": 1682350957000,^
-  \"enactmentTimestamp\": 1682437357000,^
-  \"validationTimestamp\": 1682437357000^
+  \"closingTimestamp\": 1682435906000,^
+  \"enactmentTimestamp\": 1682522306000,^
+  \"validationTimestamp\": 1682522306000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
@@ -13,7 +13,7 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string})
-  closingTimestamp: 1682350957000,
+  closingTimestamp: 1682435906000,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
@@ -13,7 +13,7 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string})
-  closingTimestamp: 1681727444000,
+  closingTimestamp: 1682350957000,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
@@ -8,7 +8,7 @@
   },
   "terms": {
    "newFreeform": {},
-   "closingTimestamp": 1682350957000
+   "closingTimestamp": 1682435906000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
@@ -8,7 +8,7 @@
   },
   "terms": {
    "newFreeform": {},
-   "closingTimestamp": 1681727444000
+   "closingTimestamp": 1682350957000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
@@ -7,7 +7,7 @@
   },
   "terms": {
     "newFreeform": {},
-    "closingTimestamp": 1681727444000
+    "closingTimestamp": 1682350957000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
@@ -7,7 +7,7 @@
   },
   "terms": {
     "newFreeform": {},
-    "closingTimestamp": 1682350957000
+    "closingTimestamp": 1682435906000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
@@ -9,7 +9,7 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
  },^
  \"terms\": {^
   \"newFreeform\": {},^
-  \"closingTimestamp\": 1682350957000^
+  \"closingTimestamp\": 1682435906000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
@@ -9,7 +9,7 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
  },^
  \"terms\": {^
   \"newFreeform\": {},^
-  \"closingTimestamp\": 1681727444000^
+  \"closingTimestamp\": 1682350957000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
@@ -27,10 +27,10 @@
     // New market instrument configuration
     instrument: {
      // Instrument name
-     name: "Oranges Daily",
+     name: "Apples Yearly (2022)",
 
      // Instrument code, human-readable shortcode used to describe the instrument
-     code: "ORANGES.24h",
+     code: "APPLES.22",
 
      // Future
      future: {
@@ -126,14 +126,14 @@
         settlementDataProperty: "prices.BTC.value",
 
         // the name of the property in the data source data that signals termination of trading (string)
-        tradingTerminationProperty: "vega.builtin.timestamp"
+        tradingTerminationProperty: "vegaprotocol.builtin.timestamp"
        }
       },
 
       // Optional new market metadata, tags
       metadata: [
-       "enactment:2023-04-18T11:30:44Z",
-       "settlement:2023-04-17T11:30:44Z",
+       "enactment:2023-04-25T16:42:37Z",
+       "settlement:2023-04-24T16:42:37Z",
        "source:docs.vega.xyz"
       ],
 
@@ -200,11 +200,11 @@
 
    // Timestamp (Unix time in seconds) when voting closes for this proposal,
    // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-   closingTimestamp: 1681727444000,
+   closingTimestamp: 1682350957000,
 
    // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
    // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-   enactmentTimestamp: 1681813844000,
+   enactmentTimestamp: 1682437357000,
   }
  }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
@@ -84,7 +84,7 @@
          {
           key: {
            name: "prices.BTC.timestamp",
-           type: "TYPE_TIMESTAMP",
+           type: "TYPE_INTEGER",
           },
           conditions: [
            {
@@ -132,8 +132,8 @@
 
       // Optional new market metadata, tags
       metadata: [
-       "enactment:2023-04-25T16:42:37Z",
-       "settlement:2023-04-24T16:42:37Z",
+       "enactment:2023-04-26T16:18:26Z",
+       "settlement:2023-04-25T16:18:26Z",
        "source:docs.vega.xyz"
       ],
 
@@ -200,11 +200,11 @@
 
    // Timestamp (Unix time in seconds) when voting closes for this proposal,
    // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-   closingTimestamp: 1682350957000,
+   closingTimestamp: 1682435906000,
 
    // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
    // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-   enactmentTimestamp: 1682437357000,
+   enactmentTimestamp: 1682522306000,
   }
  }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
@@ -47,7 +47,7 @@
            {
             "key": {
              "name": "prices.BTC.timestamp",
-             "type": "TYPE_TIMESTAMP"
+             "type": "TYPE_INTEGER"
             },
             "conditions": [
              {
@@ -79,8 +79,8 @@
       }
      },
      "metadata": [
-      "enactment:2023-04-25T16:42:37Z",
-      "settlement:2023-04-24T16:42:37Z",
+      "enactment:2023-04-26T16:18:26Z",
+      "settlement:2023-04-25T16:18:26Z",
       "source:docs.vega.xyz"
      ],
      "priceMonitoringParameters": {
@@ -111,8 +111,8 @@
      }
     }
    },
-   "closingTimestamp": 1682350957000,
-   "enactmentTimestamp": 1682437357000
+   "closingTimestamp": 1682435906000,
+   "enactmentTimestamp": 1682522306000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
@@ -15,8 +15,8 @@
      "decimalPlaces": "5",
      "positionDecimalPlaces": "5",
      "instrument": {
-      "name": "Oranges Daily",
-      "code": "ORANGES.24h",
+      "name": "Apples Yearly (2022)",
+      "code": "APPLES.22",
       "future": {
        "settlementAsset": "8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4",
        "quoteName": "tEuro",
@@ -74,13 +74,13 @@
        },
        "dataSourceSpecBinding": {
         "settlementDataProperty": "prices.BTC.value",
-        "tradingTerminationProperty": "vega.builtin.timestamp"
+        "tradingTerminationProperty": "vegaprotocol.builtin.timestamp"
        }
       }
      },
      "metadata": [
-      "enactment:2023-04-18T11:30:44Z",
-      "settlement:2023-04-17T11:30:44Z",
+      "enactment:2023-04-25T16:42:37Z",
+      "settlement:2023-04-24T16:42:37Z",
       "source:docs.vega.xyz"
      ],
      "priceMonitoringParameters": {
@@ -111,8 +111,8 @@
      }
     }
    },
-   "closingTimestamp": 1681727444000,
-   "enactmentTimestamp": 1681813844000
+   "closingTimestamp": 1682350957000,
+   "enactmentTimestamp": 1682437357000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
@@ -14,8 +14,8 @@
         "decimalPlaces": "5",
         "positionDecimalPlaces": "5",
         "instrument": {
-          "name": "Oranges Daily",
-          "code": "ORANGES.24h",
+          "name": "Apples Yearly (2022)",
+          "code": "APPLES.22",
           "future": {
             "settlementAsset": "8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4",
             "quoteName": "tEuro",
@@ -73,13 +73,13 @@
             },
             "dataSourceSpecBinding": {
               "settlementDataProperty": "prices.BTC.value",
-              "tradingTerminationProperty": "vega.builtin.timestamp"
+              "tradingTerminationProperty": "vegaprotocol.builtin.timestamp"
             }
           }
         },
         "metadata": [
-          "enactment:2023-04-18T11:30:44Z",
-          "settlement:2023-04-17T11:30:44Z",
+          "enactment:2023-04-25T16:42:37Z",
+          "settlement:2023-04-24T16:42:37Z",
           "source:docs.vega.xyz"
         ],
         "priceMonitoringParameters": {
@@ -110,8 +110,8 @@
         }
       }
     },
-    "closingTimestamp": 1681727444000,
-    "enactmentTimestamp": 1681813844000
+    "closingTimestamp": 1682350957000,
+    "enactmentTimestamp": 1682437357000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
@@ -46,7 +46,7 @@
                     {
                       "key": {
                         "name": "prices.BTC.timestamp",
-                        "type": "TYPE_TIMESTAMP"
+                        "type": "TYPE_INTEGER"
                       },
                       "conditions": [
                         {
@@ -78,8 +78,8 @@
           }
         },
         "metadata": [
-          "enactment:2023-04-25T16:42:37Z",
-          "settlement:2023-04-24T16:42:37Z",
+          "enactment:2023-04-26T16:18:26Z",
+          "settlement:2023-04-25T16:18:26Z",
           "source:docs.vega.xyz"
         ],
         "priceMonitoringParameters": {
@@ -110,8 +110,8 @@
         }
       }
     },
-    "closingTimestamp": 1682350957000,
-    "enactmentTimestamp": 1682437357000
+    "closingTimestamp": 1682435906000,
+    "enactmentTimestamp": 1682522306000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json_instrument.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json_instrument.md
@@ -1,9 +1,9 @@
 ```javascript
 {
  // Instrument name
- name: "Oranges Daily",
+ name: "Apples Yearly (2022)",
  // Instrument code, human-readable shortcode used to describe the instrument
- code: "ORANGES.24h",
+ code: "APPLES.22",
  // Future
  future: {
   // Asset ID for the product's settlement asset (string)
@@ -71,7 +71,7 @@
    // this property as settlement data. (string)
    settlementDataProperty: "prices.BTC.value",
    // the name of the property in the data source data that signals termination of trading (string)
-   tradingTerminationProperty: "vega.builtin.timestamp"
+   tradingTerminationProperty: "vegaprotocol.builtin.timestamp"
   }
  }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json_instrument.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json_instrument.md
@@ -49,7 +49,7 @@
      {
       key: {
        name: "prices.BTC.timestamp",
-       type: "TYPE_TIMESTAMP",
+       type: "TYPE_INTEGER",
       },
       conditions: [
        {

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
@@ -32,10 +32,10 @@
   },
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1682350957000,
+  closingTimestamp: 1682435906000,
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1682437357000,
+  enactmentTimestamp: 1682522306000,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
@@ -32,10 +32,10 @@
   },
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1681727444000,
+  closingTimestamp: 1682350957000,
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1681813844000,
+  enactmentTimestamp: 1682437357000,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
@@ -16,8 +16,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     \"decimalPlaces\": \"5\",^
     \"positionDecimalPlaces\": \"5\",^
     \"instrument\": {^
-     \"name\": \"Oranges Daily\",^
-     \"code\": \"ORANGES.24h\",^
+     \"name\": \"Apples Yearly (2022)\",^
+     \"code\": \"APPLES.22\",^
      \"future\": {^
       \"settlementAsset\": \"8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4\",^
       \"quoteName\": \"tEuro\",^
@@ -75,13 +75,13 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
       },^
       \"dataSourceSpecBinding\": {^
        \"settlementDataProperty\": \"prices.BTC.value\",^
-       \"tradingTerminationProperty\": \"vega.builtin.timestamp\"^
+       \"tradingTerminationProperty\": \"vegaprotocol.builtin.timestamp\"^
       }^
      }^
     },^
     \"metadata\": [^
-     \"enactment:2023-04-18T11:30:44Z\",^
-     \"settlement:2023-04-17T11:30:44Z\",^
+     \"enactment:2023-04-25T16:42:37Z\",^
+     \"settlement:2023-04-24T16:42:37Z\",^
      \"source:docs.vega.xyz\"^
     ],^
     \"priceMonitoringParameters\": {^
@@ -112,8 +112,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     }^
    }^
   },^
-  \"closingTimestamp\": 1681727444000,^
-  \"enactmentTimestamp\": 1681813844000^
+  \"closingTimestamp\": 1682350957000,^
+  \"enactmentTimestamp\": 1682437357000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
@@ -48,7 +48,7 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
           {^
            \"key\": {^
             \"name\": \"prices.BTC.timestamp\",^
-            \"type\": \"TYPE_TIMESTAMP\"^
+            \"type\": \"TYPE_INTEGER\"^
            },^
            \"conditions\": [^
             {^
@@ -80,8 +80,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
      }^
     },^
     \"metadata\": [^
-     \"enactment:2023-04-25T16:42:37Z\",^
-     \"settlement:2023-04-24T16:42:37Z\",^
+     \"enactment:2023-04-26T16:18:26Z\",^
+     \"settlement:2023-04-25T16:18:26Z\",^
      \"source:docs.vega.xyz\"^
     ],^
     \"priceMonitoringParameters\": {^
@@ -112,8 +112,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     }^
    }^
   },^
-  \"closingTimestamp\": 1682350957000,^
-  \"enactmentTimestamp\": 1682437357000^
+  \"closingTimestamp\": 1682435906000,^
+  \"enactmentTimestamp\": 1682522306000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
@@ -26,11 +26,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1681727444000,
+  closingTimestamp: 1682350957000,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1681813844000,
+  enactmentTimestamp: 1682437357000,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
@@ -26,11 +26,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1682350957000,
+  closingTimestamp: 1682435906000,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1682437357000,
+  enactmentTimestamp: 1682522306000,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
@@ -17,8 +17,8 @@
      }
     }
    },
-   "closingTimestamp": 1681727444000,
-   "enactmentTimestamp": 1681813844000
+   "closingTimestamp": 1682350957000,
+   "enactmentTimestamp": 1682437357000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
@@ -17,8 +17,8 @@
      }
     }
    },
-   "closingTimestamp": 1682350957000,
-   "enactmentTimestamp": 1682437357000
+   "closingTimestamp": 1682435906000,
+   "enactmentTimestamp": 1682522306000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
@@ -16,8 +16,8 @@
         }
       }
     },
-    "closingTimestamp": 1681727444000,
-    "enactmentTimestamp": 1681813844000
+    "closingTimestamp": 1682350957000,
+    "enactmentTimestamp": 1682437357000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
@@ -16,8 +16,8 @@
         }
       }
     },
-    "closingTimestamp": 1682350957000,
-    "enactmentTimestamp": 1682437357000
+    "closingTimestamp": 1682435906000,
+    "enactmentTimestamp": 1682522306000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
@@ -18,8 +18,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     }^
    }^
   },^
-  \"closingTimestamp\": 1682350957000,^
-  \"enactmentTimestamp\": 1682437357000^
+  \"closingTimestamp\": 1682435906000,^
+  \"enactmentTimestamp\": 1682522306000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
@@ -18,8 +18,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     }^
    }^
   },^
-  \"closingTimestamp\": 1681727444000,^
-  \"enactmentTimestamp\": 1681813844000^
+  \"closingTimestamp\": 1682350957000,^
+  \"enactmentTimestamp\": 1682437357000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
@@ -116,7 +116,7 @@
         settlementDataProperty: "prices.BTC.value",
 
         // the name of the property in the data source data that signals termination of trading (string)
-        tradingTerminationProperty: "vega.builtin.timestamp"
+        tradingTerminationProperty: "vegaprotocol.builtin.timestamp"
        }
       },
 
@@ -150,7 +150,7 @@
        tau: 0.0001140771161,
 
        // Risk Aversion Parameter (double as number)
-       riskAversionParameter: "0.01",
+       riskAversionParameter: "0.0001",
 
        // Risk model parameters for log normal
        params: {
@@ -161,7 +161,7 @@
         r: 0.016,
 
         // Sigma parameter, annualised volatility of the underlying asset, must be a strictly non-negative real number (double as number)
-        sigma: 0.3,
+        sigma: 0.5,
        }
       },
      },
@@ -169,11 +169,11 @@
 
     // Timestamp (Unix time in seconds) when voting closes for this proposal,
     // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-    closingTimestamp: 1681727444000,
+    closingTimestamp: 1682350957000,
 
     // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
     // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-    enactmentTimestamp: 1681813844000,
+    enactmentTimestamp: 1682437357000,
    }
   }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
@@ -74,7 +74,7 @@
          {
           key: {
            name: "prices.BTC.timestamp",
-           type: "TYPE_TIMESTAMP",
+           type: "TYPE_INTEGER",
           },
           conditions: [
            {
@@ -150,7 +150,7 @@
        tau: 0.0001140771161,
 
        // Risk Aversion Parameter (double as number)
-       riskAversionParameter: "0.0001",
+       riskAversionParameter: "0.001",
 
        // Risk model parameters for log normal
        params: {
@@ -161,7 +161,7 @@
         r: 0.016,
 
         // Sigma parameter, annualised volatility of the underlying asset, must be a strictly non-negative real number (double as number)
-        sigma: 0.5,
+        sigma: 1.25,
        }
       },
      },
@@ -169,11 +169,11 @@
 
     // Timestamp (Unix time in seconds) when voting closes for this proposal,
     // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-    closingTimestamp: 1682350957000,
+    closingTimestamp: 1682435906000,
 
     // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
     // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-    enactmentTimestamp: 1682437357000,
+    enactmentTimestamp: 1682522306000,
    }
   }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
@@ -44,7 +44,7 @@
            {
             "key": {
              "name": "prices.BTC.timestamp",
-             "type": "TYPE_TIMESTAMP"
+             "type": "TYPE_INTEGER"
             },
             "conditions": [
              {
@@ -89,17 +89,17 @@
      },
      "logNormal": {
       "tau": 0.0001140771161,
-      "riskAversionParameter": 0.0001,
+      "riskAversionParameter": 0.001,
       "params": {
        "mu": 0,
        "r": 0.016,
-       "sigma": 0.5
+       "sigma": 1.25
       }
      }
     }
    },
-   "closingTimestamp": 1682350957000,
-   "enactmentTimestamp": 1682437357000
+   "closingTimestamp": 1682435906000,
+   "enactmentTimestamp": 1682522306000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
@@ -71,7 +71,7 @@
        },
        "dataSourceSpecBinding": {
         "settlementDataProperty": "prices.BTC.value",
-        "tradingTerminationProperty": "vega.builtin.timestamp"
+        "tradingTerminationProperty": "vegaprotocol.builtin.timestamp"
        }
       }
      },
@@ -89,17 +89,17 @@
      },
      "logNormal": {
       "tau": 0.0001140771161,
-      "riskAversionParameter": 0.01,
+      "riskAversionParameter": 0.0001,
       "params": {
        "mu": 0,
        "r": 0.016,
-       "sigma": 0.3
+       "sigma": 0.5
       }
      }
     }
    },
-   "closingTimestamp": 1681727444000,
-   "enactmentTimestamp": 1681813844000
+   "closingTimestamp": 1682350957000,
+   "enactmentTimestamp": 1682437357000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
@@ -70,7 +70,7 @@
             },
             "dataSourceSpecBinding": {
               "settlementDataProperty": "prices.BTC.value",
-              "tradingTerminationProperty": "vega.builtin.timestamp"
+              "tradingTerminationProperty": "vegaprotocol.builtin.timestamp"
             }
           }
         },
@@ -88,17 +88,17 @@
         },
         "logNormal": {
           "tau": 0.0001140771161,
-          "riskAversionParameter": 0.01,
+          "riskAversionParameter": 0.0001,
           "params": {
             "mu": 0,
             "r": 0.016,
-            "sigma": 0.3
+            "sigma": 0.5
           }
         }
       }
     },
-    "closingTimestamp": 1681727444000,
-    "enactmentTimestamp": 1681813844000
+    "closingTimestamp": 1682350957000,
+    "enactmentTimestamp": 1682437357000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
@@ -43,7 +43,7 @@
                     {
                       "key": {
                         "name": "prices.BTC.timestamp",
-                        "type": "TYPE_TIMESTAMP"
+                        "type": "TYPE_INTEGER"
                       },
                       "conditions": [
                         {
@@ -88,17 +88,17 @@
         },
         "logNormal": {
           "tau": 0.0001140771161,
-          "riskAversionParameter": 0.0001,
+          "riskAversionParameter": 0.001,
           "params": {
             "mu": 0,
             "r": 0.016,
-            "sigma": 0.5
+            "sigma": 1.25
           }
         }
       }
     },
-    "closingTimestamp": 1682350957000,
-    "enactmentTimestamp": 1682437357000
+    "closingTimestamp": 1682435906000,
+    "enactmentTimestamp": 1682522306000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
@@ -45,7 +45,7 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
           {^
            \"key\": {^
             \"name\": \"prices.BTC.timestamp\",^
-            \"type\": \"TYPE_TIMESTAMP\"^
+            \"type\": \"TYPE_INTEGER\"^
            },^
            \"conditions\": [^
             {^
@@ -90,17 +90,17 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     },^
     \"logNormal\": {^
      \"tau\": 0.0001140771161,^
-     \"riskAversionParameter\": 0.0001,^
+     \"riskAversionParameter\": 0.001,^
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
-      \"sigma\": 0.5^
+      \"sigma\": 1.25^
      }^
     }^
    }^
   },^
-  \"closingTimestamp\": 1682350957000,^
-  \"enactmentTimestamp\": 1682437357000^
+  \"closingTimestamp\": 1682435906000,^
+  \"enactmentTimestamp\": 1682522306000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
@@ -72,7 +72,7 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
       },^
       \"dataSourceSpecBinding\": {^
        \"settlementDataProperty\": \"prices.BTC.value\",^
-       \"tradingTerminationProperty\": \"vega.builtin.timestamp\"^
+       \"tradingTerminationProperty\": \"vegaprotocol.builtin.timestamp\"^
       }^
      }^
     },^
@@ -90,17 +90,17 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     },^
     \"logNormal\": {^
      \"tau\": 0.0001140771161,^
-     \"riskAversionParameter\": 0.01,^
+     \"riskAversionParameter\": 0.0001,^
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
-      \"sigma\": 0.3^
+      \"sigma\": 0.5^
      }^
     }^
    }^
   },^
-  \"closingTimestamp\": 1681727444000,^
-  \"enactmentTimestamp\": 1681813844000^
+  \"closingTimestamp\": 1682350957000,^
+  \"enactmentTimestamp\": 1682437357000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
@@ -18,11 +18,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1681727444000,
+  closingTimestamp: 1682350957000,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1681813844000,
+  enactmentTimestamp: 1682437357000,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
@@ -18,11 +18,11 @@
 
   // Timestamp (Unix time in seconds) when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters (int64 as string)
-  closingTimestamp: 1682350957000,
+  closingTimestamp: 1682435906000,
 
   // Timestamp (Unix time in seconds) when proposal gets enacted (if passed),
   // constrained by `minEnact` and `maxEnact` network parameters (int64 as string)
-  enactmentTimestamp: 1682437357000,
+  enactmentTimestamp: 1682522306000,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
@@ -13,8 +13,8 @@
      "value": "300"
     }
    },
-   "closingTimestamp": 1681727444000,
-   "enactmentTimestamp": 1681813844000
+   "closingTimestamp": 1682350957000,
+   "enactmentTimestamp": 1682437357000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
@@ -13,8 +13,8 @@
      "value": "300"
     }
    },
-   "closingTimestamp": 1682350957000,
-   "enactmentTimestamp": 1682437357000
+   "closingTimestamp": 1682435906000,
+   "enactmentTimestamp": 1682522306000
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
@@ -12,8 +12,8 @@
         "value": "300"
       }
     },
-    "closingTimestamp": 1681727444000,
-    "enactmentTimestamp": 1681813844000
+    "closingTimestamp": 1682350957000,
+    "enactmentTimestamp": 1682437357000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
@@ -12,8 +12,8 @@
         "value": "300"
       }
     },
-    "closingTimestamp": 1682350957000,
-    "enactmentTimestamp": 1682437357000
+    "closingTimestamp": 1682435906000,
+    "enactmentTimestamp": 1682522306000
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
@@ -14,8 +14,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     \"value\": \"300\"^
    }^
   },^
-  \"closingTimestamp\": 1681727444000,^
-  \"enactmentTimestamp\": 1681813844000^
+  \"closingTimestamp\": 1682350957000,^
+  \"enactmentTimestamp\": 1682437357000^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
@@ -14,8 +14,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     \"value\": \"300\"^
    }^
   },^
-  \"closingTimestamp\": 1682350957000,^
-  \"enactmentTimestamp\": 1682437357000^
+  \"closingTimestamp\": 1682435906000,^
+  \"enactmentTimestamp\": 1682522306000^
  }^
 }^
 }"

--- a/docs/tutorials/using-data-sources.md
+++ b/docs/tutorials/using-data-sources.md
@@ -52,11 +52,11 @@ The following spec would make the market use the BTC value from the [Coinbase Pr
         "filters": [{
             "key": {
                 "name": "prices.BTC.timestamp",
-                "type": "TYPE_TIMESTAMP",
+                "type": "TYPE_INTEGER",
             },
             "conditions": [{
                 "operator": "OPERATOR_GREATER_THAN",
-                "value": "1649265840",
+                "value": "164926584000000",
             }]
         }]
     }

--- a/scripts/libGenerateProposals/newMarket.js
+++ b/scripts/libGenerateProposals/newMarket.js
@@ -260,7 +260,7 @@ function generateDataSourceSpecBinding(skeleton) {
 
   const binding = {
     settlementDataProperty: "prices.BTC.value",
-    tradingTerminationProperty: "vega.builtin.timestamp",
+    tradingTerminationProperty: "vegaprotocol.builtin.timestamp",
   };
 
   binding[inspect.custom] = () => {

--- a/scripts/libGenerateProposals/newMarket.js
+++ b/scripts/libGenerateProposals/newMarket.js
@@ -75,7 +75,7 @@ function generateSettlementDataSourceSpec(skeleton) {
           {
             key: {
               name: "prices.BTC.timestamp",
-              type: "TYPE_TIMESTAMP",
+              type: "TYPE_INTEGER",
             },
             conditions: [
               {


### PR DESCRIPTION
Fix newMarket proposal

For some reason, this was using the incorrect oracle string. Now it uses the correct one

- Fix new market sample proposal
- Regenerate all sample proposals

Closes #568