### PR TITLE
chore: update restart docs for protocol upgrade

### DIFF
--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -7,7 +7,7 @@ hide_title: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The protocol upgrade feature allows the Node Operators to synchronously update nodes to the next version of the Vega Protocol.
+The protocol upgrade feature allows node operators to automatically update nodes to a new version of the Vega protocol.
 
 A protocol upgrade has three steps: 
 1. Submit a transaction to initiate the upgrade on a specific block (validators only)
@@ -61,7 +61,7 @@ Example:
 vega protocol_upgrade_proposal \
 	--home /home/vega/vega_home \
 	--passphrase-file /home/vega/vega_home/nodewallet_passphrase.txt \
-	--vega-release-tag v0.71.0 \
+	--vega-release-tag v0.99.0 \
 	--height 1034000 \
 	--output "json"
 ```
@@ -196,7 +196,7 @@ Depending on your hardware, it might take 2-3 seconds or longer. The core and da
 
 Visor is designed to perform a protocol upgrade automatically, but you can automate it yourself. The key is to check if core is ready for a restart for a protocol upgrade. As described above, it might take several seconds between the node reaches the protocol upgrade block and marks itself as ready to be restarted. Do not solely rely on block height, e.g. from the `/statistics` endpoint.
 
-Instead, query core using the admin JSON-RPC endpoint, as this is what Visor does. Note: This might change in the future, so please keep an eye on the release notes for changes to Visor.
+Instead, query core using the admin JSON-RPC endpoint, as this is what Visor does. Note: This might change in the future, so please keep an eye on the Vega repo release notes for changes to Visor.
 
 In your `core` config (`<VEGA-NETWORK-HOME>/config/node/config.toml`), you will find:
 ```toml
@@ -230,7 +230,7 @@ Example response:
 }
 ```
 
-`ReadyToUpgrade` tells you if core is ready for shutdown for `protocol upgrade`.
+`ReadyToUpgrade` tells you if core is ready to shut down for a protocol upgrade.
 
 
 ## Benefits of using Visor to coordinate upgrades

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -11,7 +11,7 @@ The Protocol Upgrade feature allows the Node Operators to synchronously update n
 
 The Protocol Upgrade involves three main parts: 
 1. Submit a transaction to initiate the upgrade on a specific block (validators only)
-2. Prepare a Node for Protocol Upgrade
+2. Prepare a node for protocol upgrade
 3. Execute an upgrade at the agreed block
 
 Smooth execution of the Protocol Upgrade is critical to the Vega Network, and any downtime or disruption must be minimised. Using Vega Visor is recommended and will automatically prepare and execute a protocol upgrade. Alternatively, the Node Operator can manually perform an Upgrade at an agreed block height for an agreed Vega software version.

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -169,3 +169,15 @@ In the data node logs, you will see the following message:
 ```
 2023-03-02T13:01:04.379+0100	INFO	datanode.service	service/protocol_upgrade.go:36	datanode is ready for protocol upgrade
 ```
+
+#### 4. Restarting nodes
+
+### 4a. As a node operator if you are running both a Vega node and a data node:
+
+1. If using data node check the latest history segment block height (`to_height`) on data node by running: `vega datanode network-history latest-history-segment —home $DATA_NODE_HOME`
+2. First start the data node with the following command: `vega datanode start`
+3. Once the data node has started, proceed to start the Vega core node on the **same block height as data node** with the following command: `vega node —-home $VEGA_CORE_NODE_HOME --snapshot.load-from-block-height $to_height`
+
+### 4b. As a node operator if you are only running a Vega node:
+
+1. Start Vega core node with the snapshot file that is equal to the upgrade block height by running the following command: `vega node —-home $VEGA_CORE_NODE_HOME --snapshot.load-from-block-height $UPGRADE_BLOCK_HEIGHT`

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -21,7 +21,9 @@ To help with protocol upgrades, the following endpoints can provide relevant inf
 * To see if the network is ready for upgrade use the **[protocol upgrade status](../../api/rest/data-v2/trading-data-service-get-protocol-upgrade-status.api.mdx) endpoint**.
 
 
-## 1. Submit a transaction to initiate the upgrade on a specific block (validators only)
+## 1. Submit a transaction to initiate the upgrade on a specific block
+
+This step can only be done by consensus validators.
 
 ### 1.1 Select upgrade block height and new Vega version
 

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -227,7 +227,7 @@ Example response:
 `ReadyToUpgrade` tells you if `core` is ready for shutdown for `Protocol Upgrade`.
 
 
-# Benefits of using Visor to coordinate upgrades
+## Benefits of using Visor to coordinate upgrades
 
 If an upgrade proposal is approved (more than 2/3 of consensus validators have voted on it), those using Visor can rely on it to coordinate the upgrade rollout across all the nodes on the chosen block height. 
 

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 The Protocol Upgrade feature allows the Node Operators to synchronously update nodes to the next version of the Vega Protocol.
 
-The Protocol Upgrade involves three main parts: 
+A protocol upgrade has three steps: 
 1. Submit a transaction to initiate the upgrade on a specific block (validators only)
 2. Prepare a node for protocol upgrade
 3. Execute an upgrade at the agreed block

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -44,7 +44,7 @@ To check the block time on the network, visit the `http://<YOUR-NODE-IP>:3003/st
 
 All validators must execute this step, regardless of whether or not they are running Vega Visor.
 
-After all the validators agree on the `upgrade block height` and the `desired version` of the Vega, vote on an upgrade. To vote, use the following command:
+After all the validators agree on the `upgrade block height` and the `desired version` of Vega, vote on an upgrade. To vote, use the following command, as an example. Be sure to confirm the release tag and height before you continue:
 
 ```bash
 vega protocol_upgrade_proposal \
@@ -66,17 +66,17 @@ vega protocol_upgrade_proposal \
 	--output "json"
 ```
 
-The Protocol Upgrade proposal is approved if more than 2/3 of consensus validators have voted on it.
+The protocol upgrade proposal is approved if more than 2/3 of consensus validators have voted on it.
 
-Anyone can observe how the voting goes using data node **[protocol upgrade proposals](../../api/rest/data-v2/trading-data-service-list-protocol-upgrade-proposals.api.mdx) endpoint**.
+Anyone can observe how the voting goes using the **[protocol upgrade proposals](../../api/rest/data-v2/trading-data-service-list-protocol-upgrade-proposals.api.mdx) endpoint**.
 
-# 2. Prepare a Node for Protocol Upgrade
+## 2. Prepare node for protocol upgrade
 
-All Node Operators must perform these steps, regardless of whether or not they are using Vega Visor.
+All node operators must perform these steps, regardless of whether or not they are using Vega Visor.
 
-## 2.1 Prepare network configuration (all)
+### 2.1 Prepare network configuration (all)
 
-The Node Operator needs to check if the config needs upgrading. That includes:
+Each node operator needs to check if their config needs updating. That includes:
 
 1. The Vega core configuration (`<VEGA-NETWORK-HOME>/config/node/config.toml`)- only if there were changes
 2. The Tendermint configuration (`<TENDERMINT-HOME>/config/config.toml`)  - only if there were changes
@@ -84,17 +84,17 @@ The Node Operator needs to check if the config needs upgrading. That includes:
 
 Track changes in the configuration between versions in the upgrading readme: [Configuration changes ↗](https://github.com/vegaprotocol/vega/blob/develop/UPGRADING.md#configuration-changes)
 
-## 2.2 Prepare Visor configuration (visor only)
+### 2.2 Prepare Visor configuration, if using Visor
 
-Skip:
-- if you are not using Vega Visor (go to the next point 2.3),
-- if your node has Internet access (Vega Visor will do this for you),
+You can skip this step if:
+* You are not using Vega Visor (go to step 2.3)
+* Your node has internet access (Vega Visor will do this step)
 
-On the other hand, you need to perform this step if your node does not have Internat access.
+If your node does **not** have internet access and you are using Visor, do the following:
 
 1. Create the new version folder in the `<VEGA-VISOR-HOME>`, e.g., for version `v0.71.0`, run the following command: `mkdir -p <VEGA-VISOR-HOME>/v0.71.0`.
 2. Download the new version of the Vega binary from the [releases page ↗](https://github.com/vegaprotocol/vega/releases)
-3. Unzip the downloaded binary into the created directory, e.g. `<VEGA-VISOR-HOME>/v0.71.0/vega` binary.
+3. Unzip the downloaded binary into the created directory, e.g. `<VEGA-VISOR-HOME>/v0.71.0/vega` binary
 4. Create the run configuration and put it in the created directory, e.g. `<VEGA-VISOR-HOME>/v0.71.0/run-config.toml` run config file (see example below)
 
 Example config for the new version with Visor:
@@ -115,7 +115,7 @@ name = "v0.71.0"
     socketPath = "<SOCKET-FOLDER-PATH>/vega.sock"
     httpPath = "/rpc"
 
-# skip below if you don't have data node
+# skip the following if you do not run a data node ```
 [data_node]
   [data_node.binary]
     path = "vega"
@@ -132,35 +132,39 @@ Check the following parameters.
 - `--nodewallet-passphrase-file` flag - Check if the path is correct for your node wallet passphrase.
 - `vega.rpc.socketPath` - Make sure the path to the Vega Unix sock is correct and matches the one in the Vega config.
 
-Once you have performed steps `2.1 Prepare network configuration (all)` and `2.2 Prepare Visor configuration (visor only)`, you don't have to do anything else. The visor will automatically restart the node once the `core` and the `data-node` (if you run one) report they are ready for Protocol Upgrade.
+Once you have performed steps `2.1 Prepare network configuration (all)` and `2.2 Prepare Visor configuration, if using Visor`, you don't have to do anything else. Visor will automatically restart the node once the core and data node (if you run one) report they are ready for the protocol upgrade.
 
-## 2.3 Prepare for an upgrade without Vega Visor (non visor only)
+### 2.3 Prepare for an upgrade if not using Visor
 
-You should perform these steps only if you are NOT running Vega Visor.
+You should perform these steps only if you are NOT running Visor.
 
 1. Download the new version of the Vega binary from the [releases page ↗](https://github.com/vegaprotocol/vega/releases)
 2. Unzip the downloaded binary into your file system.
 3. Update your systemd (or any other process manager) to use the new binary.
 4. Reload a systemd service: `systemctl daemon-reload`, or use your own preferred.
 
-Now you are ready for `Protocol Upgrade`. Please read `3. Execute an upgrade at the agreed block (non visor only)` to know what to do next.
+Now you are ready for the protocol upgrade. Move onto the next step,`3. Execute an upgrade at the agreed block (non-Visor only)` for the next steps.
 
-# 3. Execute an upgrade at the agreed block (non visor only)
+## 3. Execute an upgrade at the agreed block (non-Visor only)
 
-You should perform these steps only if you are NOT running Vega Visor. If you use Vega Visor, it will perform these steps for you automatically.
+You should perform these steps only if you are NOT running Visor. If you use Visor, it will perform these steps for you automatically.
 
 **Important:** Smooth execution of the Protocol Upgrade is critical to the Vega Network, and any downtime or disruption must be minimised.
 
-The below steps cover both use cases: `core` only (marked `a`) and `core + data-node` (marked `b`).
+The below steps cover two use cases: for those running a core node only (marked `a`) and those running a core and data node (marked `b`).
 
-## 3.1 Wait for the `Protocol Upgrade` block
+### 3.1 Wait for the protocol upgrade block
 
-`(a)`: Monitor `/statistics` until `blockHeight` reaches the `upgrade block` and stops increasing
-`(b)`: Monitor `/statistics` of data-node REST endpoint, until both: `blockHeight` from the response body and `x-block-height` response header, both hit `upgrade block`.
+`(a)`: Monitor the `http://<YOUR-NODE-IP>:3003/statistics` endpoint until `blockHeight` reaches the `upgrade block` and stops increasing
+`(b)`: Monitor the `http://<YOUR-NODE-IP>:3003/statistics` for your data node's REST instance, until both `blockHeight` from the response body and `x-block-height` response header, both hit `upgrade block`.
 
-**Important:* both `core` and `data-node` will automatically stop processing blocks at the `Protocol Upgrade` block. Both will process any remaining data and prepare for `Protocol Upgrade` by creating a snapshot and network history segment. Depending on your hardware, it might take a couple of seconds or longer. The `core` and the `data-node` process will not exit. Instead, they both will mark themselves as ready for the upgrade. As a Node Operator, you need to check if `core` is ready for restart for `Protocol Upgrade` (`core` waits for `data-node` before marking itself as ready), then you can safely restart the `core` and `data-node` (if you run one) processes.
+:::note 
+Both the core and data node will automatically stop processing blocks at the protocol upgrade block. Both will process any remaining data and prepare for the protocol upgrade by creating a snapshot and network history segment. 
 
-## 3.2 Verify logs if it is safe to restart services
+Depending on your hardware, it might take 2-3 seconds or longer. The core and data node process will not exit. Instead, they both will mark themselves as ready for the upgrade. As a node operator, you need to check if core is ready to restart for the protocol upgrade. Core waits for data node before marking itself as ready. Then you can safely restart the core and date node (if running) processes.
+:::
+
+### 3.2 Verify from logs if it is safe to restart services
 
 `(a)` and `(b)`: In the Vega core logs, you will see the following messages:
 
@@ -183,16 +187,16 @@ The below steps cover both use cases: `core` only (marked `a`) and `core + data-
 2023-03-02T13:01:04.379+0100	INFO	datanode.service	service/protocol_upgrade.go:36	datanode is ready for protocol upgrade
 ```
 
-## 3.3 Restart services
+### 3.3 Restart services
 
 `(a)`: Restart your `core` process
-`(b)`: When you run both: `core` and `data-node`, you must stop both first, and then you can start both in any order.
+`(b)`: When you run both core and data node, you must stop both first, and then you can start both, in any order.
 
-## 3.4 Automate
+### 3.4 Automate
 
-Vega Visor is designed to perform `Protocol Upgrade` automatically, but you can automate it yourself. The key is to check if `core` is ready for a restart for `Protocol Upgrade`. As described before, it might take some time (seconds) between the node reaching the `Protocol Upgrade` block and marking itself as ready for the restart. That is why you should not rely on block height, e.g. from `/statistics`.
+Visor is designed to perform a protocol upgrade automatically, but you can automate it yourself. The key is to check if core is ready for a restart for a protocol upgrade. As described above, it might take several seconds between the node reaches the protocol upgrade block and marks itself as ready to be restarted. Do not solely rely on block height, e.g. from the `/statistics` endpoint.
 
-Instead, you need to query `core` using the Admin json rpc endpoint as this is what Vega Visor is doing. Note: This might change in the future, so please keep an eye on the release notes for changes in the Vega Visor.
+Instead, query core using the admin JSON-RPC endpoint, as this is what Visor does. Note: This might change in the future, so please keep an eye on the release notes for changes to Visor.
 
 In your `core` config (`<VEGA-NETWORK-HOME>/config/node/config.toml`), you will find:
 ```toml

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -199,7 +199,7 @@ In your `core` config (`<VEGA-NETWORK-HOME>/config/node/config.toml`), you will 
     SocketPath = "/path/to/vega.sock"
     HTTPPath = "/my-rpc"
 ```
-Then you can send request:
+Then you can send the following request:
 ```bash
 # Run it from use that has access to /path/to/vega.sock
 sudo -u vega \

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -16,7 +16,7 @@ A protocol upgrade has three steps:
 
 Smooth execution of a protocol upgrade is critical to the Vega network, and any downtime or disruption must be minimised. Using Vega Visor is recommended and will automatically prepare and execute a protocol upgrade. Alternatively, a node operator can manually perform an upgrade at an agreed block height for an agreed Vega software version.
 
-To help with Protocol Upgrades, the data node provides useful information:
+To help with protocol upgrades, the following endpoints can provide relevant information:
 * to view submitted proposals use **[protocol upgrade proposals](../../api/rest/data-v2/trading-data-service-list-protocol-upgrade-proposals.api.mdx) endpoint**,
 * to view if the network is ready for upgrade use **[protocol upgrade status](../../api/rest/data-v2/trading-data-service-get-protocol-upgrade-status.api.mdx) endpoint**.
 

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -170,14 +170,14 @@ In the data node logs, you will see the following message:
 2023-03-02T13:01:04.379+0100	INFO	datanode.service	service/protocol_upgrade.go:36	datanode is ready for protocol upgrade
 ```
 
-#### 4. Restarting nodes (for node operators NOT using Visor)
+### 4. Restarting nodes (for node operators NOT using Visor)
 
-### 4a. As a node operator if you are running both a Vega node and a data node:
+#### 4a. As a node operator if you are running both a Vega node and a data node:
 
-1. Check the latest data node network-history segment block height (`to_height`) on data node by running: `vega datanode network-history latest-history-segment —home $DATA_NODE_HOME`
+1. Check the latest data node network-history segment block height (`SEGMENT-BLOCK-HEIGHT`) on data node by running: `vega datanode network-history latest-history-segment —home $DATA_NODE_HOME`
 2. Start the data node with the following command: `vega datanode start`
-3. Once the data node has started, proceed to start the Vega core node on the **same block height as data node** with the following command: `vega node —-home $VEGA_CORE_NODE_HOME --snapshot.load-from-block-height $to_height`
+3. Once the data node has started, proceed to start the Vega core node on the **same block height as data node** with the following command: `vega node —-home $VEGA-NETWORK-HOME --snapshot.load-from-block-height $SEGMENT-BLOCK-HEIGHT`
 
-### 4b. As a node operator if you are only running a Vega node:
+#### 4b. As a node operator if you are only running a Vega node:
 
-1. Start Vega core node with the snapshot file that is equal to the upgrade block height by running the following command: `vega node —-home $VEGA_CORE_NODE_HOME --snapshot.load-from-block-height $UPGRADE_BLOCK_HEIGHT`
+1. Start Vega core node with the snapshot file that is equal to the upgrade block height by running the following command: `vega node —-home $VEGA-NETWORK-HOME --snapshot.load-from-block-height $BLOCK-HEIGHT-YOU-AGREED-ON`

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -190,7 +190,7 @@ The below steps cover both use cases: `core` only (marked `a`) and `core + data-
 
 Vega Visor is designed to perform `Protocol Upgrade` automatically, but you can automate it yourself. The key is to check if `core` is ready for a restart for `Protocol Upgrade`. As described before, it might take some time (seconds) between the node reaching the `Protocol Upgrade` block and marking itself as ready for the restart. That is why you should not rely on block height, e.g. from `/statistics`.
 
-Instead, you need to query `core` using the Admin json rpc endpoint. This is what Vega Visor is doing. Important Note: We do not have any plans, but this might change, so please watch for changes in the Vega Visor.
+Instead, you need to query `core` using the Admin json rpc endpoint as this is what Vega Visor is doing. Note: This might change in the future, so please keep an eye on the release notes for changes in the Vega Visor.
 
 In your `core` config (`<VEGA-NETWORK-HOME>/config/node/config.toml`), you will find:
 ```toml

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -35,7 +35,7 @@ This step is async, and it involves all validators. First, all validators have t
 The block height must be in the future. When choosing the `upgrade block`, you should give all validators enough time to vote on the upgrade and then prepare the config for a new network.
 
 :::info Example
-Selecting the `current block` + 1000 - should give 1000 blocks * 0.9 seconds (or whatever the average block time is) = 900 secs. That means there will be about 15 minutes for all validators to vote and prepare, which might not be enough.
+Selecting the `current block` + 1000 - should allow for 1000 blocks * 0.9 seconds (or whatever the average block time is) = 900 secs. That means there will be about 15 minutes for all validators to vote and prepare, which might not be enough.
 
 To check the block time on the network, visit the `http://<YOUR-NODE-IP>:3003/statistics` endpoint. Currently, the block time is around ~0.9 seconds, though it may be higher around ~1.5 seconds when there are not many transactions or some validators are missing.
 :::

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -7,7 +7,7 @@ hide_title: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The Protocol Upgrade feature allows the Node Operators to synchronously update nodes to the next version of the Vega Protocol.
+The protocol upgrade feature allows the Node Operators to synchronously update nodes to the next version of the Vega Protocol.
 
 A protocol upgrade has three steps: 
 1. Submit a transaction to initiate the upgrade on a specific block (validators only)
@@ -149,7 +149,7 @@ Now you are ready for the protocol upgrade. Move onto the next step,`3. Execute 
 
 You should perform these steps only if you are NOT running Visor. If you use Visor, it will perform these steps for you automatically.
 
-**Important:** Smooth execution of the Protocol Upgrade is critical to the Vega Network, and any downtime or disruption must be minimised.
+**Important:** Smooth execution of the protocol upgrade is critical to the Vega Network, and any downtime or disruption must be minimised.
 
 The below steps cover two use cases: for those running a core node only (marked `a`) and those running a core and data node (marked `b`).
 
@@ -230,7 +230,7 @@ Example response:
 }
 ```
 
-`ReadyToUpgrade` tells you if `core` is ready for shutdown for `Protocol Upgrade`.
+`ReadyToUpgrade` tells you if core is ready for shutdown for `protocol upgrade`.
 
 
 ## Benefits of using Visor to coordinate upgrades

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -224,7 +224,7 @@ Example response:
 }
 ```
 
-`ReadyToUpgrade` tells you if `core` is ready for shutdown for `Protocol Upgrade.
+`ReadyToUpgrade` tells you if `core` is ready for shutdown for `Protocol Upgrade`.
 
 
 # Benefits of using Visor to coordinate upgrades

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -144,37 +144,6 @@ You should do this step only if you are not running Visor.
 
 Now you are ready for `Protocol Upgrade`, and need to wait for the `upgrade block`.
 
-
-
-5. Wait for the `upgrade block`, then restart the network with the new binary and config after the `upgrade block` is present.
-
-#### Check if Vega core is ready for restart
-To see when your Vega core node is ready for protocol upgrade, check the Vega-core logs.
-
-In the Vega core logs, you will see the following messages:
-
-```
-2023-03-02T13:01:04.242+0100	INFO	core.protocol.processor	processor/abci.go:821	waiting for data node to get ready for upgrade
-2023-03-02T13:01:04.242+0100	INFO	tendermint	service/service.go:176	service stop	{"msg": "Stopping Node service", "impl": "Node"}
-2023-03-02T13:01:04.242+0100	INFO	tendermint	node/node.go:1010	Stopping Node
-...
-...
-2023-03-02T13:01:04.380+0100	INFO	core.protocol.protocolupgrade	protocolupgrade/engine.go:356	marking vega core and data node as ready to shut down
-2023-03-02T13:01:05.380+0100	INFO	core.protocol.processor	processor/abci.go:845	application is ready for shutdown
-2023-03-02T13:01:06.380+0100	INFO	core.protocol.processor	processor/abci.go:845	application is ready for shutdown
-2023-03-02T13:01:07.381+0100	INFO	core.protocol.processor	processor/abci.go:845	application is ready for shutdown
-...
-```
-
-#### Check if data node is ready for restart
-To see when your data node is ready for protocol upgrade, check the data node logs.
-
-In the data node logs, you will see the following message:
-
-```
-2023-03-02T13:01:04.379+0100	INFO	datanode.service	service/protocol_upgrade.go:36	datanode is ready for protocol upgrade
-```
-
 ### 4. Restarting nodes (for node operators NOT using Visor)
 
 The below steps cover both use cases: `core` only (marked `a`) and `core + data-node` (marked `b`).

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -14,7 +14,7 @@ The Protocol Upgrade involves three main parts:
 2. Prepare a Node for Protocol Upgrade
 3. Execute an upgrade at the agreed block
 
-Smooth execution of the Protocol Upgrade is critical to the Vega Network, and any downtime or disruption must be minimised. Therefore, we recommend using Vega Visor, which automatically prepares and executes an upgrade. Alternatively, the Node Operator can manually perform an Upgrade at an agreed block height for an agreed Vega software version.
+Smooth execution of the Protocol Upgrade is critical to the Vega Network, and any downtime or disruption must be minimised. Using Vega Visor is recommended and will automatically prepare and execute a protocol upgrade. Alternatively, the Node Operator can manually perform an Upgrade at an agreed block height for an agreed Vega software version.
 
 To help with Protocol Upgrades, the data node provides useful information:
 * to view submitted proposals use **[protocol upgrade proposals](../../api/rest/data-v2/trading-data-service-list-protocol-upgrade-proposals.api.mdx) endpoint**,

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -17,7 +17,7 @@ A protocol upgrade has three steps:
 Smooth execution of a protocol upgrade is critical to the Vega network, and any downtime or disruption must be minimised. Using Vega Visor is recommended and will automatically prepare and execute a protocol upgrade. Alternatively, a node operator can manually perform an upgrade at an agreed block height for an agreed Vega software version.
 
 To help with protocol upgrades, the following endpoints can provide relevant information:
-* to view submitted proposals use **[protocol upgrade proposals](../../api/rest/data-v2/trading-data-service-list-protocol-upgrade-proposals.api.mdx) endpoint**,
+* To view submitted proposals use the **[protocol upgrade proposals](../../api/rest/data-v2/trading-data-service-list-protocol-upgrade-proposals.api.mdx) endpoint**
 * To see if the network is ready for upgrade use the **[protocol upgrade status](../../api/rest/data-v2/trading-data-service-get-protocol-upgrade-status.api.mdx) endpoint**.
 
 

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -201,7 +201,7 @@ In your `core` config (`<VEGA-NETWORK-HOME>/config/node/config.toml`), you will 
 ```
 Then you can send the following request:
 ```bash
-# Run it from use that has access to /path/to/vega.sock
+# Run it from a user that has access to /path/to/vega.sock
 sudo -u vega \
     curl http://localhost/my-rpc \
         --unix-socket /path/to/vega.sock \

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -170,12 +170,12 @@ In the data node logs, you will see the following message:
 2023-03-02T13:01:04.379+0100	INFO	datanode.service	service/protocol_upgrade.go:36	datanode is ready for protocol upgrade
 ```
 
-#### 4. Restarting nodes
+#### 4. Restarting nodes (for node operators NOT using Visor)
 
 ### 4a. As a node operator if you are running both a Vega node and a data node:
 
-1. If using data node check the latest history segment block height (`to_height`) on data node by running: `vega datanode network-history latest-history-segment —home $DATA_NODE_HOME`
-2. First start the data node with the following command: `vega datanode start`
+1. Check the latest data node network-history segment block height (`to_height`) on data node by running: `vega datanode network-history latest-history-segment —home $DATA_NODE_HOME`
+2. Start the data node with the following command: `vega datanode start`
 3. Once the data node has started, proceed to start the Vega core node on the **same block height as data node** with the following command: `vega node —-home $VEGA_CORE_NODE_HOME --snapshot.load-from-block-height $to_height`
 
 ### 4b. As a node operator if you are only running a Vega node:

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -14,7 +14,7 @@ A protocol upgrade has three steps:
 2. Prepare a node for protocol upgrade
 3. Execute an upgrade at the agreed block
 
-Smooth execution of the Protocol Upgrade is critical to the Vega Network, and any downtime or disruption must be minimised. Using Vega Visor is recommended and will automatically prepare and execute a protocol upgrade. Alternatively, the Node Operator can manually perform an Upgrade at an agreed block height for an agreed Vega software version.
+Smooth execution of a protocol upgrade is critical to the Vega network, and any downtime or disruption must be minimised. Using Vega Visor is recommended and will automatically prepare and execute a protocol upgrade. Alternatively, a node operator can manually perform an upgrade at an agreed block height for an agreed Vega software version.
 
 To help with Protocol Upgrades, the data node provides useful information:
 * to view submitted proposals use **[protocol upgrade proposals](../../api/rest/data-v2/trading-data-service-list-protocol-upgrade-proposals.api.mdx) endpoint**,

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -18,7 +18,7 @@ Smooth execution of a protocol upgrade is critical to the Vega network, and any 
 
 To help with protocol upgrades, the following endpoints can provide relevant information:
 * to view submitted proposals use **[protocol upgrade proposals](../../api/rest/data-v2/trading-data-service-list-protocol-upgrade-proposals.api.mdx) endpoint**,
-* to view if the network is ready for upgrade use **[protocol upgrade status](../../api/rest/data-v2/trading-data-service-get-protocol-upgrade-status.api.mdx) endpoint**.
+* To see if the network is ready for upgrade use the **[protocol upgrade status](../../api/rest/data-v2/trading-data-service-get-protocol-upgrade-status.api.mdx) endpoint**.
 
 
 ## 1. Submit a transaction to initiate the upgrade on a specific block (validators only)

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -174,9 +174,8 @@ In the data node logs, you will see the following message:
 
 #### 4a. As a node operator if you are running both a Vega node and a data node:
 
-1. Check the latest data node network-history segment block height (`SEGMENT-BLOCK-HEIGHT`) on data node by running: `vega datanode network-history latest-history-segment —home $DATA_NODE_HOME`
-2. Start the data node with the following command: `vega datanode start`
-3. Once the data node has started, proceed to start the Vega core node on the **same block height as data node** with the following command: `vega node —-home $VEGA-NETWORK-HOME --snapshot.load-from-block-height $SEGMENT-BLOCK-HEIGHT`
+1. Start the data node with the following command: `vega datanode start`
+3. Once the data node has started, proceed to start the Vega core node with the snapshot file that is equal to the upgrade block height by running the following command: `vega node —-home $VEGA-NETWORK-HOME --snapshot.load-from-block-height $BLOCK-HEIGHT-YOU-AGREED-ON`
 
 #### 4b. As a node operator if you are only running a Vega node:
 

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -7,7 +7,7 @@ hide_title: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The Protocol Upgrade feature allows the Node Operators synchronously update nodes to the next version of the Vega Protocol.
+The Protocol Upgrade feature allows the Node Operators to synchronously update nodes to the next version of the Vega Protocol.
 
 The Protocol Upgrade involves three main parts: 
 1. Submit a transaction to initiate the upgrade on a specific block (validators only)

--- a/docs/node-operators/how-to/upgrade-network.md
+++ b/docs/node-operators/how-to/upgrade-network.md
@@ -7,57 +7,42 @@ hide_title: false
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The protocol upgrade feature allows the nodes running a network to automatically update to the latest version of the Vega protocol, without requiring manual intervention. This can be particularly useful in situations where the protocol is critical to the functioning of the system and any downtime or disruption needs to be minimised.
+The Protocol Upgrade feature allows the Node Operators synchronously update nodes to the next version of the Vega Protocol.
 
-Protocol upgrades can be done using Vega Visor, a process runner that manages the the processes of a Vega validator node and a data node. Visor starts and stops node processes, tells the node when to take a snapshot, and coordinates upgrades to the protocol.
+The Protocol Upgrade involves three main parts: 
+1. Submit a transaction to initiate the upgrade on a specific block (validators only)
+2. Prepare a Node for Protocol Upgrade
+3. Execute an upgrade at the agreed block
 
-Alternatively, a validator node operator can manually upgrade the protocol at an agreed block height, for an agreed Vega software version.
+Smooth execution of the Protocol Upgrade is critical to the Vega Network, and any downtime or disruption must be minimised. Therefore, we recommend using Vega Visor, which automatically prepares and executes an upgrade. Alternatively, the Node Operator can manually perform an Upgrade at an agreed block height for an agreed Vega software version.
 
-A protocol upgrade involves two main parts: 
-* Submitting a transaction to initiate the upgrade on a specific block
-* Using a process manager, Vega Visor, to coordinate the rollout of the upgrade, or manually upgrading at the agreed block height
+To help with Protocol Upgrades, the data node provides useful information:
+* to view submitted proposals use **[protocol upgrade proposals](../../api/rest/data-v2/trading-data-service-list-protocol-upgrade-proposals.api.mdx) endpoint**,
+* to view if the network is ready for upgrade use **[protocol upgrade status](../../api/rest/data-v2/trading-data-service-get-protocol-upgrade-status.api.mdx) endpoint**.
 
-## Using Visor to coordinate upgrades
-If an upgrade proposal is approved (more than 2/3 of consensus validators have voted on the proposal), those using Visor can rely on it to coordinate the rollout of the upgrade across all the nodes on the chosen block height. 
 
-This includes stopping the currently running nodes, ensuring that the new binaries are the correct software version, and starting new nodes. Visor also includes features such as restart capability, which allows Visor to retry the start-up several times before failing. 
+## 1. Submit a transaction to initiate the upgrade on a specific block (validators only)
 
-You can configure the number of restart attempts in the Visor config, located at `VISOR_HOME_PATH/config.toml`
+### 1.1 Select upgrade block height and new Vega version
 
-### Read more about Visor
-Read detailed information about Vega Visor, including how it works, how the config is set up and how you can edit it in the [full software description ↗](https://github.com/vegaprotocol/vega/tree/develop/visor#readme).
-
-You can also read the [architecture overview ↗](https://github.com/vegaprotocol/vega/tree/develop/visor#architecture) and [upgrade flow ↗](https://github.com/vegaprotocol/vega/tree/develop/visor#upgrade-flow) topics in the Visor readme.
-
-## API endpoints to help with protocol upgrades
-The data node exposes endpoints for a protocol upgrade. You can use them to see the number of proposals submitted and the protocol upgrade status for the network.
-
-To see proposals submitted for a protocol upgrade, use the **[protocol upgrade proposals](../../api/rest/data-v2/trading-data-service-list-protocol-upgrade-proposals.api.mdx) endpoint**.
-
-To see if the network is ready for a protocol upgrade, use the **[protocol upgrade status](../../api/rest/data-v2/trading-data-service-get-protocol-upgrade-status.api.mdx) endpoint**.
-
-## Protocol upgrade procedure: step by step
-
-### 1. Select upgrade block height and new Vega version
-This step is async and it involves all validators. First, all validators have to agree on the following:
+This step is async, and it involves all validators. First, all validators have to agree on the following:
 
 * The block height to upgrade at
 * The Vega version to upgrade to
 
-The block height must be in the future. When choosing the `upgrade block`, you should give all validators enough time to vote on the upgrade and then prepare config for a new network.
+The block height must be in the future. When choosing the `upgrade block`, you should give all validators enough time to vote on the upgrade and then prepare the config for a new network.
 
 :::info Example
-If you select the `current block` + 1000 - it should give you 1000 blocks * 1.5 seconds (or whatever the average block time is) = 1500 secs. That means you may have about 25 minutes, which may not be enough time for all of the validators to vote and prepare config.
+Selecting the `current block` + 1000 - should give 1000 blocks * 0.9 seconds (or whatever the average block time is) = 900 secs. That means there will be about 15 minutes for all validators to vote and prepare, which might not be enough.
 
-To predict the time that you allow for other validators to prepare configs and vote, check the block time on the network. To do that, visit the `http://<YOUR-NODE-IP>:3003/statistics` endpoint. When there are no transactions, the block time is about 1.5 seconds max, though it may be lower, for example, 0.8 seconds.
+To check the block time on the network, visit the `http://<YOUR-NODE-IP>:3003/statistics` endpoint. Currently, the block time is around ~0.9 seconds, though it may be higher around ~1.5 seconds when there are not many transactions or some validators are missing.
 :::
 
-### 2. Perform manual steps required for upgrade
+### 1.2 Vote for an upgrade
 
-#### a. Vote for an upgrade
-All of the validators must execute this step, regardless of whether or not you are running Vega Visor.
+All validators must execute this step, regardless of whether or not they are running Vega Visor.
 
-After all the validators agree on `upgrade block height` and the `desired version` of Vega, vote on an upgrade. To vote, use the following command:
+After all the validators agree on the `upgrade block height` and the `desired version` of the Vega, vote on an upgrade. To vote, use the following command:
 
 ```bash
 vega protocol_upgrade_proposal \
@@ -74,13 +59,22 @@ Example:
 vega protocol_upgrade_proposal \
 	--home /home/vega/vega_home \
 	--passphrase-file /home/vega/vega_home/nodewallet_passphrase.txt \
-	--vega-release-tag v0.68.2 \
+	--vega-release-tag v0.71.0 \
 	--height 1034000 \
 	--output "json"
 ```
 
-#### b. Prepare network configuration
-After you propose a protocol upgrade, prepare your configuration. 
+The Protocol Upgrade proposal is approved if more than 2/3 of consensus validators have voted on it.
+
+Anyone can observe how the voting goes using data node **[protocol upgrade proposals](../../api/rest/data-v2/trading-data-service-list-protocol-upgrade-proposals.api.mdx) endpoint**.
+
+# 2. Prepare a Node for Protocol Upgrade
+
+All Node Operators must perform these steps, regardless of whether or not they are using Vega Visor.
+
+## 2.1 Prepare network configuration (all)
+
+The Node Operator needs to check if the config needs upgrading. That includes:
 
 1. The Vega core configuration (`<VEGA-NETWORK-HOME>/config/node/config.toml`)- only if there were changes
 2. The Tendermint configuration (`<TENDERMINT-HOME>/config/config.toml`)  - only if there were changes
@@ -88,20 +82,23 @@ After you propose a protocol upgrade, prepare your configuration.
 
 Track changes in the configuration between versions in the upgrading readme: [Configuration changes ↗](https://github.com/vegaprotocol/vega/blob/develop/UPGRADING.md#configuration-changes)
 
-You must prepare the above configs whether you are running vega with a visor or not.
+## 2.2 Prepare Visor configuration (visor only)
 
-### 3a. Prepare Visor configuration
-You can skip to the next step if you are not running Visor.
+Skip:
+- if you are not using Vega Visor (go to the next point 2.3),
+- if your node has Internet access (Vega Visor will do this for you),
 
-1. Create the new version folder in the `<VEGA-VISOR-HOME>`, e.g., for version `v0.68.2`, run the following command: `mkdir -p <VEGA-VISOR-HOME>/v0.68.2`.
-2. Create the run configuration and put it in the folder created in the previous point (see example below)
-3. Download the new version of the Vega binary from the [releases page ↗](https://github.com/vegaprotocol/vega/releases)
-4. Unzip the downloaded binary into the `<VEGA-VISOR-HOME>/v0.68.2` directory.
+On the other hand, you need to perform this step if your node does not have Internat access.
+
+1. Create the new version folder in the `<VEGA-VISOR-HOME>`, e.g., for version `v0.71.0`, run the following command: `mkdir -p <VEGA-VISOR-HOME>/v0.71.0`.
+2. Download the new version of the Vega binary from the [releases page ↗](https://github.com/vegaprotocol/vega/releases)
+3. Unzip the downloaded binary into the created directory, e.g. `<VEGA-VISOR-HOME>/v0.71.0/vega` binary.
+4. Create the run configuration and put it in the created directory, e.g. `<VEGA-VISOR-HOME>/v0.71.0/run-config.toml` run config file (see example below)
 
 Example config for the new version with Visor:
 
 ```toml
-name = "v0.68.2"
+name = "v0.71.0"
 
 [vega]
   [vega.binary]
@@ -116,6 +113,7 @@ name = "v0.68.2"
     socketPath = "<SOCKET-FOLDER-PATH>/vega.sock"
     httpPath = "/rpc"
 
+# skip below if you don't have data node
 [data_node]
   [data_node.binary]
     path = "vega"
@@ -127,33 +125,40 @@ name = "v0.68.2"
 
 Check the following parameters.
 
-- `name` - This must match to the  folder name created in `step 3a`
+- `name` - This must match the created directory
 - `vega.binary.path` - It may be an absolute path or a relative (to config folder) path. Change that path when you have unzipped the new binary into a different folder.
 - `--nodewallet-passphrase-file` flag - Check if the path is correct for your node wallet passphrase.
 - `vega.rpc.socketPath` - Make sure the path to the Vega Unix sock is correct and matches the one in the Vega config.
 
-Once you have updated your Visor run config and the network config, you have to wait for the upgrade block. Visor will listen for the upgrade event and restart your binaries. 
+Once you have performed steps `2.1 Prepare network configuration (all)` and `2.2 Prepare Visor configuration (visor only)`, you don't have to do anything else. The visor will automatically restart the node once the `core` and the `data-node` (if you run one) report they are ready for Protocol Upgrade.
 
-### 3b. Prepare upgrade if not running Visor
-You should do this step only if you are not running Visor.
+## 2.3 Prepare for an upgrade without Vega Visor (non visor only)
+
+You should perform these steps only if you are NOT running Vega Visor.
 
 1. Download the new version of the Vega binary from the [releases page ↗](https://github.com/vegaprotocol/vega/releases)
 2. Unzip the downloaded binary into your file system.
 3. Update your systemd (or any other process manager) to use the new binary.
 4. Reload a systemd service: `systemctl daemon-reload`, or use your own preferred.
 
-Now you are ready for `Protocol Upgrade`, and need to wait for the `upgrade block`.
+Now you are ready for `Protocol Upgrade`. Please read `3. Execute an upgrade at the agreed block (non visor only)` to know what to do next.
 
-### 4. Restarting nodes (for node operators NOT using Visor)
+# 3. Execute an upgrade at the agreed block (non visor only)
+
+You should perform these steps only if you are NOT running Vega Visor. If you use Vega Visor, it will perform these steps for you automatically.
+
+**Important:** Smooth execution of the Protocol Upgrade is critical to the Vega Network, and any downtime or disruption must be minimised.
 
 The below steps cover both use cases: `core` only (marked `a`) and `core + data-node` (marked `b`).
 
-#### 4.1 Wait for `Protocol Upgrade` block
+## 3.1 Wait for the `Protocol Upgrade` block
 
 `(a)`: Monitor `/statistics` until `blockHeight` reaches the `upgrade block` and stops increasing
-`(b)`: Monitor `/statistics` of data-node REST endpoint, until both: `blockHeight` from the body and `x-block-height` response header, both hit `upgrade block`.
+`(b)`: Monitor `/statistics` of data-node REST endpoint, until both: `blockHeight` from the response body and `x-block-height` response header, both hit `upgrade block`.
 
-#### 4.2 Verify logs if it is safe to restart services
+**Important:* both `core` and `data-node` will automatically stop processing blocks at the `Protocol Upgrade` block. Both will process any remaining data and prepare for `Protocol Upgrade` by creating a snapshot and network history segment. Depending on your hardware, it might take a couple of seconds or longer. The `core` and the `data-node` process will not exit. Instead, they both will mark themselves as ready for the upgrade. As a Node Operator, you need to check if `core` is ready for restart for `Protocol Upgrade` (`core` waits for `data-node` before marking itself as ready), then you can safely restart the `core` and `data-node` (if you run one) processes.
+
+## 3.2 Verify logs if it is safe to restart services
 
 `(a)` and `(b)`: In the Vega core logs, you will see the following messages:
 
@@ -176,14 +181,61 @@ The below steps cover both use cases: `core` only (marked `a`) and `core + data-
 2023-03-02T13:01:04.379+0100	INFO	datanode.service	service/protocol_upgrade.go:36	datanode is ready for protocol upgrade
 ```
 
-#### 4.3 Restart services
+## 3.3 Restart services
 
-`(a)`: As a node operator if you are only running a Vega node:
+`(a)`: Restart your `core` process
+`(b)`: When you run both: `core` and `data-node`, you must stop both first, and then you can start both in any order.
 
-1. Start Vega core node with the snapshot file that is equal to the upgrade block height by running the following command: `vega node —-home $VEGA-NETWORK-HOME --snapshot.load-from-block-height $BLOCK-HEIGHT-YOU-AGREED-ON` (TODO: I don't think we need `--snapshot.load-from-block-height`, can someone confirm?)
+## 3.4 Automate
 
-`(b)`: As a node operator if you are running both a Vega node and a data node:
+Vega Visor is designed to perform `Protocol Upgrade` automatically, but you can automate it yourself. The key is to check if `core` is ready for a restart for `Protocol Upgrade`. As described before, it might take some time (seconds) between the node reaching the `Protocol Upgrade` block and marking itself as ready for the restart. That is why you should not rely on block height, e.g. from `/statistics`.
 
-1. Start the data node with the following command: `vega datanode start`
-3. Once the data node has started, proceed to start the Vega core node with the snapshot file that is equal to the upgrade block height by running the following command: `vega node —-home $VEGA-NETWORK-HOME --snapshot.load-from-block-height $BLOCK-HEIGHT-YOU-AGREED-ON` (TODO: I don't think we need `--snapshot.load-from-block-height`, can someone confirm?)
+Instead, you need to query `core` using the Admin json rpc endpoint. This is what Vega Visor is doing. Important Note: We do not have any plans, but this might change, so please watch for changes in the Vega Visor.
 
+In your `core` config (`<VEGA-NETWORK-HOME>/config/node/config.toml`), you will find:
+```toml
+[Admin]
+  [Admin.Server]
+    SocketPath = "/path/to/vega.sock"
+    HTTPPath = "/my-rpc"
+```
+Then you can send request:
+```bash
+# Run it from use that has access to /path/to/vega.sock
+sudo -u vega \
+    curl http://localhost/my-rpc \
+        --unix-socket /path/to/vega.sock \
+         -H 'Content-Type: application/json' \
+        --data '{"jsonrpc": "2.0", "method": "protocolupgrade.UpgradeStatus", "params": [], "id": "id"}'
+```
+
+Example response:
+```json
+{
+    "result": {
+        "AcceptedReleaseInfo": {
+            "VegaReleaseTag":"",
+            "UpgradeBlockHeight":0
+        },
+        "ReadyToUpgrade":false
+    },
+    "error":null,
+    "id":"id"
+}
+```
+
+`ReadyToUpgrade` tells you if `core` is ready for shutdown for `Protocol Upgrade.
+
+
+# Benefits of using Visor to coordinate upgrades
+
+If an upgrade proposal is approved (more than 2/3 of consensus validators have voted on it), those using Visor can rely on it to coordinate the upgrade rollout across all the nodes on the chosen block height. 
+
+This includes stopping the currently running nodes, ensuring the new binaries are the correct software version, and starting new nodes. Visor also includes features such as restart capability, which allows Visor to retry the start-up several times before failing. 
+
+You can configure the number of restart attempts in the Visor config, located at `VISOR_HOME_PATH/config.toml`
+
+### Read more about Visor
+Read detailed information about Vega Visor, including how it works, how the config is set up and how to edit it in the [full software description ↗](https://github.com/vegaprotocol/vega/tree/develop/visor#readme).
+
+You can also read the [architecture overview ↗](https://github.com/vegaprotocol/vega/tree/develop/visor#architecture) and [upgrade flow ↗](https://github.com/vegaprotocol/vega/tree/develop/visor#upgrade-flow) topics in the Visor readme.


### PR DESCRIPTION
To add some further detail for protocol upgrades to try and mitigate node operators using unsafe-reset-all during a protocol upgrade.

close #577 .

@karlem @daniel1302 - please can you review what has been added here? I have a few questions:

- does this apply to ONLY users not running Visor (i.e. will Visor do all this for them if they are using it)
- should we capture a final step that says "if you see X, Y, Z in the logs the nodes are running as expected" so node operators can validate all went swimmingly 