### PR TITLE
Redirect vega-protocol page to governance page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -79,3 +79,8 @@
   from = "/testnet/concepts/vega-protocol"
   to = "/testnet/concepts/governance"
   status = 301
+
+  [[redirects]]
+  from = "/mainnet/concepts/vega-protocol"
+  to = "/mainnet/concepts/governance"
+  status = 301


### PR DESCRIPTION
Replicates a redirect that was already done for the testnet side. 