### PR TITLE
Fix incorrect governance links

### DIFF
--- a/versioned_docs/version-v0.71/tutorials/proposals/freeform-proposal.md
+++ b/versioned_docs/version-v0.71/tutorials/proposals/freeform-proposal.md
@@ -35,7 +35,7 @@ You will need:
 
 ## Templates and submitting
 
-In the tabs below you'll see an annotated example, which describes what each field is for, a JSON example, and command line examples for different operating systems. The Governance dApp has a [tool to help you put together a Freeform proposal](https://governance.fairground.wtf/proposals/propose/network-parameter). When you have your proposal ready you can [submit it on the governance dApp](https://governance.vega.xyz/proposals/propose/raw).
+In the tabs below you'll see an annotated example, which describes what each field is for, a JSON example, and command line examples for different operating systems. The Governance dApp has a [tool to help you put together a Freeform proposal](https://governance.vega.xyz/proposals/propose/freeform). When you have your proposal ready you can [submit it on the governance dApp](https://governance.vega.xyz/proposals/propose/raw).
 
 <Tabs groupId="newFreeform">
   <TabItem value="annotated" label="Annotated example">

--- a/versioned_docs/version-v0.71/tutorials/proposals/network-parameter-proposal.md
+++ b/versioned_docs/version-v0.71/tutorials/proposals/network-parameter-proposal.md
@@ -41,7 +41,7 @@ The contents of a `changes` object specifies what will be different after the pr
 **Value** is the new value you're proposing that the network parameter should have.
 
 ## Templates and submitting
-In the tabs below you'll see an annotated example, which describes what each field is for, a JSON example, and command line examples for different operating systems. The Governance dApp has a [tool to help you put together a Network Parameter update proposal](https://governance.fairground.wtf/proposals/propose/network-parameter). When you have your proposal ready you can [submit it on the governance dApp](https://governance.vega.xyz/proposals/propose/raw). 
+In the tabs below you'll see an annotated example, which describes what each field is for, a JSON example, and command line examples for different operating systems. The Governance dApp has a [tool to help you put together a Network Parameter update proposal](https://governance.vega.xyz/proposals/propose/network-parameter). When you have your proposal ready you can [submit it on the governance dApp](https://governance.vega.xyz/proposals/propose/raw). 
 
 <Tabs groupId="updateNetworkParameter">
   <TabItem value="annotated" label="Annotated example">


### PR DESCRIPTION
We missed some incorrect uses of the testnet governance site in the mainnet section. This PR fixes both.