### PR TITLE
fix: example timestamps should be in seconds, not milliseconds, since epoch

### DIFF
--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
@@ -38,14 +38,14 @@
 
   // Timestamp as Unix time in seconds when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters. (int64 as string)
-  closingTimestamp: 1685288048000,
+  closingTimestamp: 1685551078,
 
   // Timestamp as Unix time in seconds when proposal gets enacted if passed,
   // constrained by `minEnact` and `maxEnact` network parameters. (int64 as string)
-  enactmentTimestamp: 1685374448000,
+  enactmentTimestamp: 1685637478,
 
   // Validation timestamp as Unix time in seconds. (int64 as string)
-  validationTimestamp: 1685374448000
+  validationTimestamp: 1685637478
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_annotated.md
@@ -38,14 +38,14 @@
 
   // Timestamp as Unix time in seconds when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters. (int64 as string)
-  closingTimestamp: 1685551078,
+  closingTimestamp: 1685553047,
 
   // Timestamp as Unix time in seconds when proposal gets enacted if passed,
   // constrained by `minEnact` and `maxEnact` network parameters. (int64 as string)
-  enactmentTimestamp: 1685637478,
+  enactmentTimestamp: 1685639447,
 
   // Validation timestamp as Unix time in seconds. (int64 as string)
-  validationTimestamp: 1685637478
+  validationTimestamp: 1685639447
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
@@ -20,9 +20,9 @@
      }
     }
    },
-   "closingTimestamp": 1685288048000,
-   "enactmentTimestamp": 1685374448000,
-   "validationTimestamp": 1685374448000
+   "closingTimestamp": 1685551078,
+   "enactmentTimestamp": 1685637478,
+   "validationTimestamp": 1685637478
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_cmd.md
@@ -20,9 +20,9 @@
      }
     }
    },
-   "closingTimestamp": 1685551078,
-   "enactmentTimestamp": 1685637478,
-   "validationTimestamp": 1685637478
+   "closingTimestamp": 1685553047,
+   "enactmentTimestamp": 1685639447,
+   "validationTimestamp": 1685639447
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
@@ -19,9 +19,9 @@
         }
       }
     },
-    "closingTimestamp": 1685288048000,
-    "enactmentTimestamp": 1685374448000,
-    "validationTimestamp": 1685374448000
+    "closingTimestamp": 1685551078,
+    "enactmentTimestamp": 1685637478,
+    "validationTimestamp": 1685637478
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_json.md
@@ -19,9 +19,9 @@
         }
       }
     },
-    "closingTimestamp": 1685551078,
-    "enactmentTimestamp": 1685637478,
-    "validationTimestamp": 1685637478
+    "closingTimestamp": 1685553047,
+    "enactmentTimestamp": 1685639447,
+    "validationTimestamp": 1685639447
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
@@ -21,9 +21,9 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     }^
    }^
   },^
-  \"closingTimestamp\": 1685288048000,^
-  \"enactmentTimestamp\": 1685374448000,^
-  \"validationTimestamp\": 1685374448000^
+  \"closingTimestamp\": 1685551078,^
+  \"enactmentTimestamp\": 1685637478,^
+  \"validationTimestamp\": 1685637478^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newAsset_win.md
@@ -21,9 +21,9 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     }^
    }^
   },^
-  \"closingTimestamp\": 1685551078,^
-  \"enactmentTimestamp\": 1685637478,^
-  \"validationTimestamp\": 1685637478^
+  \"closingTimestamp\": 1685553047,^
+  \"enactmentTimestamp\": 1685639447,^
+  \"validationTimestamp\": 1685639447^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
@@ -13,7 +13,7 @@
 
   // Timestamp as Unix time in seconds when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters. (int64 as string})
-  closingTimestamp: 1685551078,
+  closingTimestamp: 1685553047,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_annotated.md
@@ -13,7 +13,7 @@
 
   // Timestamp as Unix time in seconds when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters. (int64 as string})
-  closingTimestamp: 1685288048000,
+  closingTimestamp: 1685551078,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
@@ -8,7 +8,7 @@
   },
   "terms": {
    "newFreeform": {},
-   "closingTimestamp": 1685551078
+   "closingTimestamp": 1685553047
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_cmd.md
@@ -8,7 +8,7 @@
   },
   "terms": {
    "newFreeform": {},
-   "closingTimestamp": 1685288048000
+   "closingTimestamp": 1685551078
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
@@ -7,7 +7,7 @@
   },
   "terms": {
     "newFreeform": {},
-    "closingTimestamp": 1685551078
+    "closingTimestamp": 1685553047
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_json.md
@@ -7,7 +7,7 @@
   },
   "terms": {
     "newFreeform": {},
-    "closingTimestamp": 1685288048000
+    "closingTimestamp": 1685551078
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
@@ -9,7 +9,7 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
  },^
  \"terms\": {^
   \"newFreeform\": {},^
-  \"closingTimestamp\": 1685288048000^
+  \"closingTimestamp\": 1685551078^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newFreeform_win.md
@@ -9,7 +9,7 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
  },^
  \"terms\": {^
   \"newFreeform\": {},^
-  \"closingTimestamp\": 1685551078^
+  \"closingTimestamp\": 1685553047^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
@@ -130,8 +130,8 @@
 
       // Optional new market metadata, tags.
       metadata: [
-       "enactment:2023-05-29T16:34:08Z",
-       "settlement:2023-05-28T16:34:08Z",
+       "enactment:1970-01-20T13:13:57Z",
+       "settlement:1970-01-20T13:12:31Z",
        "source:docs.vega.xyz"
       ],
 
@@ -199,11 +199,11 @@
 
    // Timestamp as Unix time in seconds when voting closes for this proposal,
    // constrained by `minClose` and `maxClose` network parameters. (int64 as string)
-   closingTimestamp: 1685288048000,
+   closingTimestamp: 1685551078,
 
    // Timestamp as Unix time in seconds when proposal gets enacted if passed,
    // constrained by `minEnact` and `maxEnact` network parameters. (int64 as string)
-   enactmentTimestamp: 1685374448000,
+   enactmentTimestamp: 1685637478,
   }
  }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_annotated.md
@@ -130,8 +130,8 @@
 
       // Optional new market metadata, tags.
       metadata: [
-       "enactment:1970-01-20T13:13:57Z",
-       "settlement:1970-01-20T13:12:31Z",
+       "enactment:2023-06-01T18:10:47Z",
+       "settlement:2023-05-31T18:10:47Z",
        "source:docs.vega.xyz"
       ],
 
@@ -199,11 +199,11 @@
 
    // Timestamp as Unix time in seconds when voting closes for this proposal,
    // constrained by `minClose` and `maxClose` network parameters. (int64 as string)
-   closingTimestamp: 1685551078,
+   closingTimestamp: 1685553047,
 
    // Timestamp as Unix time in seconds when proposal gets enacted if passed,
    // constrained by `minEnact` and `maxEnact` network parameters. (int64 as string)
-   enactmentTimestamp: 1685637478,
+   enactmentTimestamp: 1685639447,
   }
  }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
@@ -79,8 +79,8 @@
       }
      },
      "metadata": [
-      "enactment:1970-01-20T13:13:57Z",
-      "settlement:1970-01-20T13:12:31Z",
+      "enactment:2023-06-01T18:10:47Z",
+      "settlement:2023-05-31T18:10:47Z",
       "source:docs.vega.xyz"
      ],
      "priceMonitoringParameters": {
@@ -111,8 +111,8 @@
      }
     }
    },
-   "closingTimestamp": 1685551078,
-   "enactmentTimestamp": 1685637478
+   "closingTimestamp": 1685553047,
+   "enactmentTimestamp": 1685639447
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_cmd.md
@@ -79,8 +79,8 @@
       }
      },
      "metadata": [
-      "enactment:2023-05-29T16:34:08Z",
-      "settlement:2023-05-28T16:34:08Z",
+      "enactment:1970-01-20T13:13:57Z",
+      "settlement:1970-01-20T13:12:31Z",
       "source:docs.vega.xyz"
      ],
      "priceMonitoringParameters": {
@@ -111,8 +111,8 @@
      }
     }
    },
-   "closingTimestamp": 1685288048000,
-   "enactmentTimestamp": 1685374448000
+   "closingTimestamp": 1685551078,
+   "enactmentTimestamp": 1685637478
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
@@ -78,8 +78,8 @@
           }
         },
         "metadata": [
-          "enactment:2023-05-29T16:34:08Z",
-          "settlement:2023-05-28T16:34:08Z",
+          "enactment:1970-01-20T13:13:57Z",
+          "settlement:1970-01-20T13:12:31Z",
           "source:docs.vega.xyz"
         ],
         "priceMonitoringParameters": {
@@ -110,8 +110,8 @@
         }
       }
     },
-    "closingTimestamp": 1685288048000,
-    "enactmentTimestamp": 1685374448000
+    "closingTimestamp": 1685551078,
+    "enactmentTimestamp": 1685637478
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json.md
@@ -78,8 +78,8 @@
           }
         },
         "metadata": [
-          "enactment:1970-01-20T13:13:57Z",
-          "settlement:1970-01-20T13:12:31Z",
+          "enactment:2023-06-01T18:10:47Z",
+          "settlement:2023-05-31T18:10:47Z",
           "source:docs.vega.xyz"
         ],
         "priceMonitoringParameters": {
@@ -110,8 +110,8 @@
         }
       }
     },
-    "closingTimestamp": 1685551078,
-    "enactmentTimestamp": 1685637478
+    "closingTimestamp": 1685553047,
+    "enactmentTimestamp": 1685639447
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
@@ -32,10 +32,10 @@
   },
   // Timestamp as Unix time in seconds when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters. (int64 as string)
-  closingTimestamp: 1685551078,
+  closingTimestamp: 1685553047,
   // Timestamp as Unix time in seconds when proposal gets enacted if passed,
   // constrained by `minEnact` and `maxEnact` network parameters. (int64 as string)
-  enactmentTimestamp: 1685637478,
+  enactmentTimestamp: 1685639447,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_json_overview.md
@@ -32,10 +32,10 @@
   },
   // Timestamp as Unix time in seconds when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters. (int64 as string)
-  closingTimestamp: 1685288048000,
+  closingTimestamp: 1685551078,
   // Timestamp as Unix time in seconds when proposal gets enacted if passed,
   // constrained by `minEnact` and `maxEnact` network parameters. (int64 as string)
-  enactmentTimestamp: 1685374448000,
+  enactmentTimestamp: 1685637478,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
@@ -80,8 +80,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
      }^
     },^
     \"metadata\": [^
-     \"enactment:1970-01-20T13:13:57Z\",^
-     \"settlement:1970-01-20T13:12:31Z\",^
+     \"enactment:2023-06-01T18:10:47Z\",^
+     \"settlement:2023-05-31T18:10:47Z\",^
      \"source:docs.vega.xyz\"^
     ],^
     \"priceMonitoringParameters\": {^
@@ -112,8 +112,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     }^
    }^
   },^
-  \"closingTimestamp\": 1685551078,^
-  \"enactmentTimestamp\": 1685637478^
+  \"closingTimestamp\": 1685553047,^
+  \"enactmentTimestamp\": 1685639447^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newMarket_win.md
@@ -80,8 +80,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
      }^
     },^
     \"metadata\": [^
-     \"enactment:2023-05-29T16:34:08Z\",^
-     \"settlement:2023-05-28T16:34:08Z\",^
+     \"enactment:1970-01-20T13:13:57Z\",^
+     \"settlement:1970-01-20T13:12:31Z\",^
      \"source:docs.vega.xyz\"^
     ],^
     \"priceMonitoringParameters\": {^
@@ -112,8 +112,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     }^
    }^
   },^
-  \"closingTimestamp\": 1685288048000,^
-  \"enactmentTimestamp\": 1685374448000^
+  \"closingTimestamp\": 1685551078,^
+  \"enactmentTimestamp\": 1685637478^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
@@ -26,11 +26,11 @@
 
   // Timestamp as Unix time in seconds when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters. (int64 as string)
-  closingTimestamp: 1685288048000,
+  closingTimestamp: 1685551078,
 
   // Timestamp as Unix time in seconds when proposal gets enacted if passed,
   // constrained by `minEnact` and `maxEnact` network parameters. (int64 as string)
-  enactmentTimestamp: 1685374448000,
+  enactmentTimestamp: 1685637478,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_annotated.md
@@ -26,11 +26,11 @@
 
   // Timestamp as Unix time in seconds when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters. (int64 as string)
-  closingTimestamp: 1685551078,
+  closingTimestamp: 1685553047,
 
   // Timestamp as Unix time in seconds when proposal gets enacted if passed,
   // constrained by `minEnact` and `maxEnact` network parameters. (int64 as string)
-  enactmentTimestamp: 1685637478,
+  enactmentTimestamp: 1685639447,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
@@ -17,8 +17,8 @@
      }
     }
    },
-   "closingTimestamp": 1685551078,
-   "enactmentTimestamp": 1685637478
+   "closingTimestamp": 1685553047,
+   "enactmentTimestamp": 1685639447
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_cmd.md
@@ -17,8 +17,8 @@
      }
     }
    },
-   "closingTimestamp": 1685288048000,
-   "enactmentTimestamp": 1685374448000
+   "closingTimestamp": 1685551078,
+   "enactmentTimestamp": 1685637478
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
@@ -16,8 +16,8 @@
         }
       }
     },
-    "closingTimestamp": 1685288048000,
-    "enactmentTimestamp": 1685374448000
+    "closingTimestamp": 1685551078,
+    "enactmentTimestamp": 1685637478
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_json.md
@@ -16,8 +16,8 @@
         }
       }
     },
-    "closingTimestamp": 1685551078,
-    "enactmentTimestamp": 1685637478
+    "closingTimestamp": 1685553047,
+    "enactmentTimestamp": 1685639447
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
@@ -18,8 +18,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     }^
    }^
   },^
-  \"closingTimestamp\": 1685551078,^
-  \"enactmentTimestamp\": 1685637478^
+  \"closingTimestamp\": 1685553047,^
+  \"enactmentTimestamp\": 1685639447^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateAsset_win.md
@@ -18,8 +18,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     }^
    }^
   },^
-  \"closingTimestamp\": 1685288048000,^
-  \"enactmentTimestamp\": 1685374448000^
+  \"closingTimestamp\": 1685551078,^
+  \"enactmentTimestamp\": 1685637478^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
@@ -149,7 +149,7 @@
        must be a strictly non - negative real number.(number) tau: 0.0001140771161,
 
        // Risk Aversion Parameter. (double as number)
-       riskAversionParameter: "0.0001",
+       riskAversionParameter: "0.01",
 
        // Risk model parameters for log normal
        params: {
@@ -160,7 +160,7 @@
         r: 0.016,
 
         // Sigma parameter, annualised volatility of the underlying asset, must be a strictly non-negative real number. (double as number)
-        sigma: 1.25,
+        sigma: 0.5,
        }
       },
      },
@@ -168,11 +168,11 @@
 
     // Timestamp as Unix time in seconds when voting closes for this proposal,
     // constrained by `minClose` and `maxClose` network parameters. (int64 as string)
-    closingTimestamp: 1685288048000,
+    closingTimestamp: 1685551078,
 
     // Timestamp as Unix time in seconds when proposal gets enacted if passed,
     // constrained by `minEnact` and `maxEnact` network parameters. (int64 as string)
-    enactmentTimestamp: 1685374448000,
+    enactmentTimestamp: 1685637478,
    }
   }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_annotated.md
@@ -149,7 +149,7 @@
        must be a strictly non - negative real number.(number) tau: 0.0001140771161,
 
        // Risk Aversion Parameter. (double as number)
-       riskAversionParameter: "0.01",
+       riskAversionParameter: "0.0001",
 
        // Risk model parameters for log normal
        params: {
@@ -160,7 +160,7 @@
         r: 0.016,
 
         // Sigma parameter, annualised volatility of the underlying asset, must be a strictly non-negative real number. (double as number)
-        sigma: 0.5,
+        sigma: 1.25,
        }
       },
      },
@@ -168,11 +168,11 @@
 
     // Timestamp as Unix time in seconds when voting closes for this proposal,
     // constrained by `minClose` and `maxClose` network parameters. (int64 as string)
-    closingTimestamp: 1685551078,
+    closingTimestamp: 1685553047,
 
     // Timestamp as Unix time in seconds when proposal gets enacted if passed,
     // constrained by `minEnact` and `maxEnact` network parameters. (int64 as string)
-    enactmentTimestamp: 1685637478,
+    enactmentTimestamp: 1685639447,
    }
   }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
@@ -89,17 +89,17 @@
      },
      "logNormal": {
       "tau": 0.0001140771161,
-      "riskAversionParameter": 0.0001,
+      "riskAversionParameter": 0.01,
       "params": {
        "mu": 0,
        "r": 0.016,
-       "sigma": 1.25
+       "sigma": 0.5
       }
      }
     }
    },
-   "closingTimestamp": 1685288048000,
-   "enactmentTimestamp": 1685374448000
+   "closingTimestamp": 1685551078,
+   "enactmentTimestamp": 1685637478
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_cmd.md
@@ -89,17 +89,17 @@
      },
      "logNormal": {
       "tau": 0.0001140771161,
-      "riskAversionParameter": 0.01,
+      "riskAversionParameter": 0.0001,
       "params": {
        "mu": 0,
        "r": 0.016,
-       "sigma": 0.5
+       "sigma": 1.25
       }
      }
     }
    },
-   "closingTimestamp": 1685551078,
-   "enactmentTimestamp": 1685637478
+   "closingTimestamp": 1685553047,
+   "enactmentTimestamp": 1685639447
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
@@ -88,17 +88,17 @@
         },
         "logNormal": {
           "tau": 0.0001140771161,
-          "riskAversionParameter": 0.0001,
+          "riskAversionParameter": 0.01,
           "params": {
             "mu": 0,
             "r": 0.016,
-            "sigma": 1.25
+            "sigma": 0.5
           }
         }
       }
     },
-    "closingTimestamp": 1685288048000,
-    "enactmentTimestamp": 1685374448000
+    "closingTimestamp": 1685551078,
+    "enactmentTimestamp": 1685637478
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_json.md
@@ -88,17 +88,17 @@
         },
         "logNormal": {
           "tau": 0.0001140771161,
-          "riskAversionParameter": 0.01,
+          "riskAversionParameter": 0.0001,
           "params": {
             "mu": 0,
             "r": 0.016,
-            "sigma": 0.5
+            "sigma": 1.25
           }
         }
       }
     },
-    "closingTimestamp": 1685551078,
-    "enactmentTimestamp": 1685637478
+    "closingTimestamp": 1685553047,
+    "enactmentTimestamp": 1685639447
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
@@ -90,17 +90,17 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     },^
     \"logNormal\": {^
      \"tau\": 0.0001140771161,^
-     \"riskAversionParameter\": 0.0001,^
+     \"riskAversionParameter\": 0.01,^
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
-      \"sigma\": 1.25^
+      \"sigma\": 0.5^
      }^
     }^
    }^
   },^
-  \"closingTimestamp\": 1685288048000,^
-  \"enactmentTimestamp\": 1685374448000^
+  \"closingTimestamp\": 1685551078,^
+  \"enactmentTimestamp\": 1685637478^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateMarket_win.md
@@ -90,17 +90,17 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     },^
     \"logNormal\": {^
      \"tau\": 0.0001140771161,^
-     \"riskAversionParameter\": 0.01,^
+     \"riskAversionParameter\": 0.0001,^
      \"params\": {^
       \"mu\": 0,^
       \"r\": 0.016,^
-      \"sigma\": 0.5^
+      \"sigma\": 1.25^
      }^
     }^
    }^
   },^
-  \"closingTimestamp\": 1685551078,^
-  \"enactmentTimestamp\": 1685637478^
+  \"closingTimestamp\": 1685553047,^
+  \"enactmentTimestamp\": 1685639447^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
@@ -18,11 +18,11 @@
 
   // Timestamp as Unix time in seconds when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters. (int64 as string)
-  closingTimestamp: 1685288048000,
+  closingTimestamp: 1685551078,
 
   // Timestamp as Unix time in seconds when proposal gets enacted if passed,
   // constrained by `minEnact` and `maxEnact` network parameters. (int64 as string)
-  enactmentTimestamp: 1685374448000,
+  enactmentTimestamp: 1685637478,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_annotated.md
@@ -18,11 +18,11 @@
 
   // Timestamp as Unix time in seconds when voting closes for this proposal,
   // constrained by `minClose` and `maxClose` network parameters. (int64 as string)
-  closingTimestamp: 1685551078,
+  closingTimestamp: 1685553047,
 
   // Timestamp as Unix time in seconds when proposal gets enacted if passed,
   // constrained by `minEnact` and `maxEnact` network parameters. (int64 as string)
-  enactmentTimestamp: 1685637478,
+  enactmentTimestamp: 1685639447,
  }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
@@ -13,8 +13,8 @@
      "value": "300"
     }
    },
-   "closingTimestamp": 1685551078,
-   "enactmentTimestamp": 1685637478
+   "closingTimestamp": 1685553047,
+   "enactmentTimestamp": 1685639447
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_cmd.md
@@ -13,8 +13,8 @@
      "value": "300"
     }
    },
-   "closingTimestamp": 1685288048000,
-   "enactmentTimestamp": 1685374448000
+   "closingTimestamp": 1685551078,
+   "enactmentTimestamp": 1685637478
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
@@ -12,8 +12,8 @@
         "value": "300"
       }
     },
-    "closingTimestamp": 1685288048000,
-    "enactmentTimestamp": 1685374448000
+    "closingTimestamp": 1685551078,
+    "enactmentTimestamp": 1685637478
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_json.md
@@ -12,8 +12,8 @@
         "value": "300"
       }
     },
-    "closingTimestamp": 1685551078,
-    "enactmentTimestamp": 1685637478
+    "closingTimestamp": 1685553047,
+    "enactmentTimestamp": 1685639447
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
@@ -14,8 +14,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     \"value\": \"300\"^
    }^
   },^
-  \"closingTimestamp\": 1685288048000,^
-  \"enactmentTimestamp\": 1685374448000^
+  \"closingTimestamp\": 1685551078,^
+  \"enactmentTimestamp\": 1685637478^
  }^
 }^
 }"

--- a/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_updateNetworkParameter_win.md
@@ -14,8 +14,8 @@ vegawallet.exe transaction send --wallet your_walletname --pubkey your_public_ke
     \"value\": \"300\"^
    }^
   },^
-  \"closingTimestamp\": 1685551078,^
-  \"enactmentTimestamp\": 1685637478^
+  \"closingTimestamp\": 1685553047,^
+  \"enactmentTimestamp\": 1685639447^
  }^
 }^
 }"

--- a/scripts/generate_proposals.js
+++ b/scripts/generate_proposals.js
@@ -114,30 +114,30 @@ function addTermsAnnotator(skeleton, terms, type) {
 function daysInTheFuture(daysToAdd) {
   const date = Date.now()
   const d = addDays(new Date(date), daysToAdd)
-  // Unix Timestamp nano
-  return getUnixTime(d) * 1000
+  // Unix Timestamp
+  return getUnixTime(d)
 }
 
 function newProposal(p, skeleton, type, partialProposal) {
-  
+
   assert.ok(skeleton.properties.closingTimestamp)
   assert.ok(skeleton.properties.enactmentTimestamp)
 
   const proposal = p
   proposal.terms.closingTimestamp = partialProposal.terms.closingTimestamp
-      
+
   // Freeform proposals don't get enacted, so they can't have this
   if (type !== 'newFreeform') {
     proposal.terms.enactmentTimestamp = partialProposal.terms.enactmentTimestamp
   }
   if (type === 'newAsset') {
     proposal.terms.validationTimestamp = partialProposal.terms.enactmentTimestamp
-  }  
+  }
   proposal.terms[inspect.custom] = addTermsAnnotator(
     skeleton,
     proposal.terms,
     type)
-  
+
   const formatOptions = {
     indent: ' '
   }
@@ -260,7 +260,7 @@ function parse(api) {
       if (ProposalGenerator.has(type)) {
         const proposal = { terms: {} }
         proposal.terms.closingTimestamp = daysInTheFuture(19)
-      
+
         // Freeform proposals don't get enacted, so they can't have this
         if (type !== 'newFreeform') {
           proposal.terms.enactmentTimestamp = daysInTheFuture(20)
@@ -268,7 +268,7 @@ function parse(api) {
         if (type === 'newAsset') {
           proposal.terms.validationTimestamp = daysInTheFuture(18)
         }
-            
+
         // TODO move in to new Proposal so we can use dates in metadata
         const changes = ProposalGenerator.get(type)(proposalTypes[type], proposal)
         output(

--- a/scripts/libGenerateProposals/newMarket.js
+++ b/scripts/libGenerateProposals/newMarket.js
@@ -2,7 +2,7 @@ const sample = require("lodash/sample");
 const random = require("lodash/random");
 const assert = require("assert").strict;
 const { inspect } = require("util");
-const { format } = require("date-fns");
+const { format, fromUnixTime } = require("date-fns");
 
 // Shortcut for deeply nested stuff
 const p = 'properties'
@@ -618,8 +618,8 @@ function generateLiquidityMonitoringParameters(skeleton) {
 
 function generateMetadata(skeleton, proposalSoFar) {
   const dateFormat = "yyyy-MM-dd\'T\'HH:mm:ss"
-  const settlement = format(proposalSoFar.terms.closingTimestamp, dateFormat)
-  const enactment = format(proposalSoFar.terms.enactmentTimestamp, dateFormat)
+  const settlement = format(fromUnixTime(proposalSoFar.terms.closingTimestamp), dateFormat)
+  const enactment = format(fromUnixTime(proposalSoFar.terms.enactmentTimestamp), dateFormat)
 
   assert.equal(
     skeleton.type,


### PR DESCRIPTION
In the generated examples of proposals, the example code given was passing in timestamps as number of milliseconds since the epoch, rather than number of seconds which is what is actually required.