### PR TITLE
chore: fix 404 on load

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,9 @@
 {
   "github": {
-    "silent": false,
-    "trailingSlashes": true
+    "silent": false
    },
+   "trailingSlash": false,
+   "cleanUrls": true,
    "redirects": [
     {
       "source": "/docs/testnet/grpc/:path*",


### PR DESCRIPTION
Change vercel configuration to match the old Netlify setup. This prevents a brief flash of 404.