### PR TITLE
Add sample code repo to community page

### DIFF
--- a/docs/concepts/assets/deposits-withdrawals.md
+++ b/docs/concepts/assets/deposits-withdrawals.md
@@ -41,7 +41,7 @@ Note: Associated and deposited are not equivalent, as deposited tokens are held 
 ### Lifetime deposit limits 
 During alpha mainnet, the ERC-20 bridge smart contract limits how much can ever be deposited from an Ethereum address. This is done in an abundance of caution, to assure users in the face of recent bridge hacks on other projects, that they would have only a small amount at risk at any point. 
 
-If, however, a user wanted to bypass those limits and understood the risks to their assets, they could run `exempt_depositor()` on the [ERC-20 bridge contract](../../api/bridge/contracts/index.md) for each asset, after which transactions greater than deposit limit for the asset would be allowed.
+If, however, a user wanted to bypass those limits and understood the risks to their assets, they could run `exempt_depositor()` for an asset on the [ERC-20 bridge contract](../../api/bridge/index.md), after which transactions greater than deposit limit for the asset would be allowed.
 
 ### Depositing ERC-20 assets
 Deposits go through the ERC-20 bridge smart contract. Every type of asset supported by and voted into Vega will have a bridge, but for the time being there is only an ERC-20 bridge.

--- a/docs/concepts/trading-on-vega/fees-rewards.md
+++ b/docs/concepts/trading-on-vega/fees-rewards.md
@@ -25,16 +25,18 @@ Fees are calculated when a trade is filled, and paid in the market's settlement 
 
 The fee is divided between the maker for the trade, the infrastructure providers, and the liquidity provider(s) for each market.
 
-#### Maker fee
+### Maker fee
 The maker portion of the fee is paid by the aggressive party in a trade (the taker), and transferred to the non-aggressive, or passive party in the trade (the maker, as opposed to the taker). This is done as soon as the trade settles.
 
-#### Infrastructure fee
+### Infrastructure fee
 The infrastructure portion of the fee is paid to validators as a reward for running the network infrastructure, and transferred to the infrastructure fee pool for the market's settlement asset. It is then distributed to the validators at the end of each epoch, in proportion to the number of tokens they represent. 
 
 Some of the infrastructure fee paid to validators is then distributed to the validators' nominators.
 
-#### Liquidity fee
-The liquidity portion of the fee is paid by a participant who hits an order on the order book, and is paid to those participants who commit liquidity to the market. It's transferred to a liquidity fee account, and distributed to each liquidity provider's margin account at a defined time (based on network parameter <NetworkParameter frontMatter={frontMatter} param="market.liquidity.providers.fee.distributionTimeStep" />), and depending on how much their liquidity commitments have contributed to the market.
+### Liquidity fee
+The liquidity portion of the fee is paid by a participant who hits an order on the order book, and is paid to those participants who [commit liquidity](../liquidity/provision.md#liquidity-commitments) to the market.
+
+It's transferred to a liquidity fee account, and distributed to each liquidity provider's margin account at a defined time (based on network parameter <NetworkParameter frontMatter={frontMatter} param="market.liquidity.providers.fee.distributionTimeStep" />), and depending on how much their liquidity commitments have contributed to the market.
 
 ### Fee calculations
 At a high level, the trading fee is calculated using the following formulas:

--- a/docs/tutorials/community-created.md
+++ b/docs/tutorials/community-created.md
@@ -24,7 +24,11 @@ The following example libraries provide code for submitting signed transactions 
 * [Authenticator (Java) ↗](https://github.com/MM0819/vega-protocol-auth-java)
 
 ### Bot sample code
-See some sample bot code for how to submit orders using the APIs [github.com/jeremyletang/vegamm ↗](https://github.com/jeremyletang/vegamm). Note that this code may not be actively maintained, so you should to test it before using it on an active network.
+Sample code for submitting orders using the APIs: [github.com/jeremyletang/vegamm ↗](https://github.com/jeremyletang/vegamm).
+
+Example Python setup code for running a simple market maker: [github.com/MM0819/vega-protocol-market-maker-python ↗](https://github.com/MM0819/vega-protocol-market-maker-python)
+
+Note that these repos and the code within them may not be actively maintained, so you should to test it before using it on an active network.
 
 ### Ask Vega AI
 **[Ask Vega ↗](https://github.com/vega-builders-club/askvega-ai)**: An AI support app for learning about the Vega protocol. 

--- a/versioned_docs/version-v0.71/concepts/assets/deposits-withdrawals.md
+++ b/versioned_docs/version-v0.71/concepts/assets/deposits-withdrawals.md
@@ -36,7 +36,7 @@ Note: Associated and deposited are not equivalent, as deposited tokens are held 
 ### Lifetime deposit limits 
 During alpha mainnet, the ERC-20 bridge smart contract limits how much can ever be deposited from an Ethereum address. This is done in an abundance of caution, to assure users in the face of recent bridge hacks on other projects, that they would have only a small amount at risk at any point. 
 
-If, however, a user wanted to bypass those limits and understood the risks to their assets, they could run `exempt_depositor()` on the [ERC-20 bridge contract](../../api/bridge/contracts/index.md) for each asset, after which transactions greater than deposit limit for the asset would be allowed.
+If, however, a user wanted to bypass those limits and **understood the risks to their assets**, they could run `exempt_depositor()` for an asset on the [ERC-20 bridge contract ↗](https://etherscan.io/address/0x23872549ce10b40e31d6577e0a920088b0e0666a/advanced#writeContract), after which transactions greater than the deposit limit for the asset would be allowed.
 
 ### Depositing ERC-20 assets
 Deposits go through the ERC-20 bridge smart contract. Every type of asset supported by and voted into Vega will have a bridge, but for the time being there is only an ERC-20 bridge.
@@ -77,7 +77,6 @@ Once the transaction is verified, the Vega public key submitted in the transacti
 To remove assets from the Vega network, submit a withdrawal request via a Vega app, such as the Vega Console trading interface, or using [Etherscan](../../tutorials/assets-tokens/withdrawing-assets.md). 
 
 This request, if valid, will be put through consensus - the validators sign a multi-signature withdrawal order bundle for the ERC-20 bridge. The bridge validates the bundle and then releases the funds to the chosen Ethereum wallet.
-
 
 If it's a successful withdrawal transaction, the ERC20 bridge will emit an `Asset_Withdrawn` event, and confirm to the Vega network that the withdrawal has been completed.
 

--- a/versioned_docs/version-v0.71/concepts/trading-on-vega/fees-rewards.md
+++ b/versioned_docs/version-v0.71/concepts/trading-on-vega/fees-rewards.md
@@ -25,16 +25,18 @@ Fees are calculated when a trade is filled, and paid in the market's settlement 
 
 The fee is divided between the maker for the trade, the infrastructure providers, and the liquidity provider(s) for each market.
 
-#### Maker fee
+### Maker fee
 The maker portion of the fee is paid by the aggressive party in a trade (the taker), and transferred to the non-aggressive, or passive party in the trade (the maker, as opposed to the taker). This is done as soon as the trade settles.
 
-#### Infrastructure fee
+### Infrastructure fee
 The infrastructure portion of the fee is paid to validators as a reward for running the network infrastructure, and transferred to the infrastructure fee pool for the market's settlement asset. It is then distributed to the validators at the end of each epoch, in proportion to the number of tokens they represent. 
 
 Some of the infrastructure fee paid to validators is then distributed to the validators' nominators.
 
-#### Liquidity fee
-The liquidity portion of the fee is paid by a participant who hits an order on the order book, and is paid to those participants who commit liquidity to the market. It's transferred to a liquidity fee account, and distributed to each liquidity provider's margin account at a defined time (based on network parameter <NetworkParameter frontMatter={frontMatter} param="market.liquidity.providers.fee.distributionTimeStep" />), and depending on how much their liquidity commitments have contributed to the market.
+### Liquidity fee
+The liquidity portion of the fee is paid by a participant who hits an order on the order book, and is paid to those participants who [commit liquidity](../liquidity/provision.md#liquidity-commitments) to the market.
+
+It's transferred to a liquidity fee account, and distributed to each liquidity provider's margin account at a defined time (based on network parameter <NetworkParameter frontMatter={frontMatter} param="market.liquidity.providers.fee.distributionTimeStep" />), and depending on how much their liquidity commitments have contributed to the market.
 
 ### Fee calculations
 At a high level, the trading fee is calculated using the following formulas:

--- a/versioned_docs/version-v0.71/tutorials/community-created.md
+++ b/versioned_docs/version-v0.71/tutorials/community-created.md
@@ -24,7 +24,11 @@ The following example libraries provide code for submitting signed transactions 
 * [Authenticator (Java) ↗](https://github.com/MM0819/vega-protocol-auth-java)
 
 ### Bot sample code
-See some sample bot code for how to submit orders using the APIs [github.com/jeremyletang/vegamm ↗](https://github.com/jeremyletang/vegamm). Note that this code may not be actively maintained, so you should to test it before using it on an active network.
+Sample code for submitting orders using the APIs: [github.com/jeremyletang/vegamm ↗](https://github.com/jeremyletang/vegamm).
+
+Example Python setup code for running a simple market maker: [github.com/MM0819/vega-protocol-market-maker-python ↗](https://github.com/MM0819/vega-protocol-market-maker-python)
+
+Note that these repos and the code within them may not be actively maintained, so you should to test it before using it on an active network.
 
 ### Ask Vega AI
 **[Ask Vega ↗](https://github.com/vega-builders-club/askvega-ai)**: An AI support app for learning about the Vega protocol. 


### PR DESCRIPTION
Add sample code repo to the community guides page, and tidy up some links and heading hierarchy