### PR TITLE
wont be merged: summary for validators

### DIFF
--- a/docs/node-operators/get-started/setup-datanode.md
+++ b/docs/node-operators/get-started/setup-datanode.md
@@ -60,6 +60,7 @@ Type "help" for help.
 vega=#
 ```
 
+
 The `POSTGRES_?` values set above need to match with the values specified in the data node configuration file (`$YOUR_DATANODE_HOME_PATH/config/data-node/config.toml`). If you want to change from the default values above, make sure you update the values in both places.
 
 ### PostgreSQL configuration tuning (optional)


### PR DESCRIPTION
This PR is created to share information with validators.


Difference between the archival node and the standard node:

- Archival node - keeps all the information about the network since block 0. People can query it when they need this data. 
- Standard node - keep only 7 days of data for most of the network elements, and 30 days for the important ones. It is not very useful for people when they are doing trading because 7 days of data is not much to analyze.


We recommend the following software: https://docs.vega.xyz/testnet/node-operators/requirements/data-node-infrastructure

We run the following server:

- CPU: `Intel(R) Xeon(R) Platinum 8280 CPU @ 2.70GHz, 8 cores`
- RAM: 32 GB
- HDD: 1 TB NVME Drive

We run only archival nodes, and you can check the resource usage below on the shared charts.

We did some testing for ZFS vs no ZFS. 

- RAM usage is 1-1.5GB higher per 1TB of storage
- CPU usage is significantly higher loaded - especially on writes IOPS and node load is higher.

But paying with a CPU and a small amount of RAM you are getting a lot of space.

See the table below:

| File system     | ZFS   | no ZFS |
|-----------------|-------|--------|
| vega_home       | 22GB  | 35GB   |
| tendermint_home | 145GB | 218GB  |
| network_history | 370GB | 393GB  |
| postgresql_home | 197GB | 1.4TB  |
| total | 734GB |  2046GB |


The above numbers are when you sync your node from block 0. We keep all the network data, but when you start from the remote snapshot and do not keep the full network history, You can cut space on the following things:

- tendermint home - because you won't keep old 20 mln blocks
- network history - you will keep only a certain amount of blocks in the network history segments

When you do not run the archival node, your postgress will be smaller, but there is only 200GB when ZFS is enabled. When the ZFS is disabled, you can see above it could use 1.4TB of data.


The compression algorithm We are using for ZFS is zstd

```
# zfs get compression -r vega_pool
NAME                            PROPERTY     VALUE           SOURCE
vega_pool                       compression  off             default
vega_pool/home                  compression  zstd            local
vega_pool/home/network-history  compression  zstd            inherited from vega_pool/home
vega_pool/home/postgresql       compression  zstd            inherited from vega_pool/home
vega_pool/home/tendermint_home  compression  zstd            inherited from vega_pool/home
```

The design of mount points is:

```
# zfs list
NAME                                   MOUNTPOINT
vega_pool                               /vega_pool
vega_pool/home                          /home/vega
vega_pool/home/network-history          /home/vega/network-history
vega_pool/home/postgresql               /home/vega/postgresql
vega_pool/home/tendermint_home          /home/vega/tendermint_home
````

The above design gives us flexibility for adding quotas, moving around, and creating snapshots for certain system elements separately.

## Data-node resources usage:

### CPU usage - 7 days

![image](https://github.com/vegaprotocol/documentation/assets/1239637/2d705429-e177-4d3b-93a6-ea8387e13a5e)

### CPU usage - 30 days

![image](https://github.com/vegaprotocol/documentation/assets/1239637/d5e44bb4-5be3-4e68-bfd4-a3340ce6a4de)

### Memory usage in GB - 7 days

![image](https://github.com/vegaprotocol/documentation/assets/1239637/4fab266a-4997-4868-ac0b-b948f2deba3e)

### Memory usage in GB - 30 days

![image](https://github.com/vegaprotocol/documentation/assets/1239637/95b9c3de-bc84-489e-90d1-3312007fe479)

### Server Load - 7 days

![image](https://github.com/vegaprotocol/documentation/assets/1239637/98740163-0675-44d9-bce9-7a5c71017db3)

### Server load - 30 days

![image](https://github.com/vegaprotocol/documentation/assets/1239637/6fd1127e-e40b-4c41-b19f-e16d5ff872e7)
