### PR TITLE
fix successor market examples

### DIFF
--- a/docs/tutorials/proposals/_generated-proposals/_newSuccessorMarket_annotated.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newSuccessorMarket_annotated.md
@@ -8,6 +8,15 @@
  terms: {
   newMarket: {
    changes: {
+    // Successor configuration. If this proposal is meant to succeed a given market, then this should be set.
+    successor: {
+     // ID of the market that the successor should take over from.
+     parentMarketId: "marketid",
+
+     // A decimal value between or equal to 0 and 1, specifying the fraction of the insurance pool balance that is carried over from the parent market to the successor.
+     insurancePoolFraction: "1"
+    },
+
     // Linear slippage factor is used to cap the slippage component of maintenance margin - it is applied to the slippage volume.
     linearSlippageFactor: 0.001,
 
@@ -23,10 +32,10 @@
     // Instrument configuration
     instrument: {
      // Instrument name.
-     name: "Apples Yearly (2022)",
+     name: "Oranges Daily",
 
      // Instrument code, human-readable shortcode used to describe the instrument.
-     code: "APPLES.22",
+     code: "ORANGES.24h",
 
      // Future product configuration
      future: {
@@ -126,8 +135,8 @@
 
       // Optional new futures market metadata, tags.
       metadata: [
-       "enactment:2023-11-26T17:53:59Z",
-       "settlement:2023-11-25T17:53:59Z",
+       "enactment:2024-01-03T15:20:02Z",
+       "settlement:2024-01-02T15:20:02Z",
        "source:docs.vega.xyz"
       ],
 
@@ -211,11 +220,11 @@
 
    // Timestamp as Unix time in seconds when voting closes for this proposal,
    // constrained by `minClose` and `maxClose` network parameters. (int64 as string)
-   closingTimestamp: 1700934839,
+   closingTimestamp: 1704208802,
 
    // Timestamp as Unix time in seconds when proposal gets enacted if passed,
    // constrained by `minEnact` and `maxEnact` network parameters. (int64 as string)
-   enactmentTimestamp: 1701021239,
+   enactmentTimestamp: 1704295202,
   }
  }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newSuccessorMarket_cmd.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newSuccessorMarket_cmd.md
@@ -9,13 +9,17 @@
   "terms": {
    "newMarket": {
     "changes": {
+     "successor": {
+      "parentMarketId": "marketid",
+      "insurancePoolFraction": "1"
+     },
      "linearSlippageFactor": "0.001",
      "quadraticSlippageFactor": "0",
      "decimalPlaces": "5",
      "positionDecimalPlaces": "5",
      "instrument": {
-      "name": "Apples Yearly (2022)",
-      "code": "APPLES.22",
+      "name": "Oranges Daily",
+      "code": "ORANGES.24h",
       "future": {
        "settlementAsset": "8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4",
        "quoteName": "tEuro",
@@ -78,8 +82,8 @@
       }
      },
      "metadata": [
-      "enactment:2023-11-26T17:53:59Z",
-      "settlement:2023-11-25T17:53:59Z",
+      "enactment:2024-01-03T15:20:02Z",
+      "settlement:2024-01-02T15:20:02Z",
       "source:docs.vega.xyz"
      ],
      "priceMonitoringParameters": {
@@ -116,8 +120,8 @@
      }
     }
    },
-   "closingTimestamp": 1700934839,
-   "enactmentTimestamp": 1701021239
+   "closingTimestamp": 1704208802,
+   "enactmentTimestamp": 1704295202
   }
  }
 }'

--- a/docs/tutorials/proposals/_generated-proposals/_newSuccessorMarket_json.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newSuccessorMarket_json.md
@@ -8,13 +8,17 @@
   "terms": {
     "newMarket": {
       "changes": {
+        "successor": {
+          "parentMarketId": "marketid",
+          "insurancePoolFraction": "1"
+        },
         "linearSlippageFactor": "0.001",
         "quadraticSlippageFactor": "0",
         "decimalPlaces": "5",
         "positionDecimalPlaces": "5",
         "instrument": {
-          "name": "Apples Yearly (2022)",
-          "code": "APPLES.22",
+          "name": "Oranges Daily",
+          "code": "ORANGES.24h",
           "future": {
             "settlementAsset": "8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4",
             "quoteName": "tEuro",
@@ -77,8 +81,8 @@
           }
         },
         "metadata": [
-          "enactment:2023-11-26T17:53:59Z",
-          "settlement:2023-11-25T17:53:59Z",
+          "enactment:2024-01-03T15:20:02Z",
+          "settlement:2024-01-02T15:20:02Z",
           "source:docs.vega.xyz"
         ],
         "priceMonitoringParameters": {
@@ -115,8 +119,8 @@
         }
       }
     },
-    "closingTimestamp": 1700934839,
-    "enactmentTimestamp": 1701021239
+    "closingTimestamp": 1704208802,
+    "enactmentTimestamp": 1704295202
   }
 }
 ```

--- a/docs/tutorials/proposals/_generated-proposals/_newSuccessorMarket_win.md
+++ b/docs/tutorials/proposals/_generated-proposals/_newSuccessorMarket_win.md
@@ -10,13 +10,17 @@ vegawallet.exe transaction send --wallet YOUR_WALLETNAME --pubkey YOUR_PUBLIC_KE
  \"terms\": {^
   \"newMarket\": {^
    \"changes\": {^
+    \"successor\": {^
+     \"parentMarketId\": \"marketid\",^
+     \"insurancePoolFraction\": \"1\"^
+    },^
     \"linearSlippageFactor\": \"0.001\",^
     \"quadraticSlippageFactor\": \"0\",^
     \"decimalPlaces\": \"5\",^
     \"positionDecimalPlaces\": \"5\",^
     \"instrument\": {^
-     \"name\": \"Apples Yearly (2022)\",^
-     \"code\": \"APPLES.22\",^
+     \"name\": \"Oranges Daily\",^
+     \"code\": \"ORANGES.24h\",^
      \"future\": {^
       \"settlementAsset\": \"8b52d4a3a4b0ffe733cddbc2b67be273816cfeb6ca4c8b339bac03ffba08e4e4\",^
       \"quoteName\": \"tEuro\",^
@@ -79,8 +83,8 @@ vegawallet.exe transaction send --wallet YOUR_WALLETNAME --pubkey YOUR_PUBLIC_KE
      }^
     },^
     \"metadata\": [^
-     \"enactment:2023-11-26T17:53:59Z\",^
-     \"settlement:2023-11-25T17:53:59Z\",^
+     \"enactment:2024-01-03T15:20:02Z\",^
+     \"settlement:2024-01-02T15:20:02Z\",^
      \"source:docs.vega.xyz\"^
     ],^
     \"priceMonitoringParameters\": {^
@@ -117,8 +121,8 @@ vegawallet.exe transaction send --wallet YOUR_WALLETNAME --pubkey YOUR_PUBLIC_KE
     }^
    }^
   },^
-  \"closingTimestamp\": 1700934839,^
-  \"enactmentTimestamp\": 1701021239^
+  \"closingTimestamp\": 1704208802,^
+  \"enactmentTimestamp\": 1704295202^
  }^
 }^
 }"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -48,7 +48,7 @@ echo ""
 
 # Inject more testnet servers for testnet
 ## Run vaguer and store the output
-#./scripts/build-pre-vaguer.sh
+./scripts/build-pre-vaguer.sh
 
 
 # Generate OpenAPI from swagger 
@@ -65,7 +65,8 @@ yarn run generate-grpc
 yarn run docusaurus clean-api-docs all
 yarn run generate-rest
 
-yarn run generate-proposals
+echo "Skipping automatic proposal generation. Run `yarn run generate-proposals` manually to update them
+# yarn run generate-proposals
 yarn run generate-openrpc
 
 echo ""

--- a/scripts/libGenerateProposals/newMarket.js
+++ b/scripts/libGenerateProposals/newMarket.js
@@ -9,7 +9,6 @@ const p = 'properties'
 
 // Seed data: Some inspirational instrument names and corresponding codes
 const instruments = [
-  { name: "Apples Yearly (2022)", code: "APPLES.22" },
   { name: "Oranges Daily", code: "ORANGES.24h" },
 ];
 

--- a/scripts/libGenerateProposals/newSuccessorMarket.js
+++ b/scripts/libGenerateProposals/newSuccessorMarket.js
@@ -34,6 +34,10 @@ function newSuccessorMarket(skeleton, proposalSoFar) {
     terms: {
       newMarket: {
         changes: {
+          successor: {
+            parentMarketId: "marketid",
+            insurancePoolFraction: "1"
+          },
           linearSlippageFactor: "0.001",
           quadraticSlippageFactor: "0",
           decimalPlaces: "5",
@@ -69,6 +73,13 @@ function newSuccessorMarket(skeleton, proposalSoFar) {
   result.terms.newMarket[inspect.custom] = () => {
     return `{
         changes: {
+          // ${skeleton.properties.changes.properties.successor.description}
+          successor: {
+            // ${skeleton.properties.changes.properties.successor.properties.parentMarketId.description}
+            parentMarketId: "${result.terms.newMarket.changes.successor.parentMarketId}",
+            // ${skeleton.properties.changes.properties.successor.properties.insurancePoolFraction.description}
+            insurancePoolFraction: "${result.terms.newMarket.changes.successor.insurancePoolFraction}"
+          },
           // ${skeleton.properties.changes.properties.linearSlippageFactor.description}
           linearSlippageFactor: ${result.terms.newMarket.changes.linearSlippageFactor},
           // ${skeleton.properties.changes.properties.quadraticSlippageFactor.description}

--- a/versioned_docs/version-v0.73/tutorials/proposals/_generated-proposals/_newSuccessorMarket_annotated.md
+++ b/versioned_docs/version-v0.73/tutorials/proposals/_generated-proposals/_newSuccessorMarket_annotated.md
@@ -8,6 +8,15 @@
  terms: {
   newMarket: {
    changes: {
+    // Successor configuration. If this proposal is meant to succeed a given market, then this should be set.
+    successor: {
+     // ID of the market that the successor should take over from.
+     parentMarketId: "marketid",
+
+     // A decimal value between or equal to 0 and 1, specifying the fraction of the insurance pool balance that is carried over from the parent market to the successor.
+     insurancePoolFraction: "1"
+    },
+
     // Linear slippage factor is used to cap the slippage component of maintenance margin - it is applied to the slippage volume.
     linearSlippageFactor: 0.001,
 
@@ -126,8 +135,8 @@
 
       // Optional new futures market metadata, tags.
       metadata: [
-       "enactment:2023-11-20T17:59:33Z",
-       "settlement:2023-11-19T17:59:33Z",
+       "enactment:2024-01-03T15:20:02Z",
+       "settlement:2024-01-02T15:20:02Z",
        "source:docs.vega.xyz"
       ],
 
@@ -211,11 +220,11 @@
 
    // Timestamp as Unix time in seconds when voting closes for this proposal,
    // constrained by `minClose` and `maxClose` network parameters. (int64 as string)
-   closingTimestamp: 1700416773,
+   closingTimestamp: 1704208802,
 
    // Timestamp as Unix time in seconds when proposal gets enacted if passed,
    // constrained by `minEnact` and `maxEnact` network parameters. (int64 as string)
-   enactmentTimestamp: 1700503173,
+   enactmentTimestamp: 1704295202,
   }
  }
 ```

--- a/versioned_docs/version-v0.73/tutorials/proposals/_generated-proposals/_newSuccessorMarket_cmd.md
+++ b/versioned_docs/version-v0.73/tutorials/proposals/_generated-proposals/_newSuccessorMarket_cmd.md
@@ -9,6 +9,10 @@
   "terms": {
    "newMarket": {
     "changes": {
+     "successor": {
+      "parentMarketId": "marketid",
+      "insurancePoolFraction": "1"
+     },
      "linearSlippageFactor": "0.001",
      "quadraticSlippageFactor": "0",
      "decimalPlaces": "5",
@@ -78,8 +82,8 @@
       }
      },
      "metadata": [
-      "enactment:2023-11-20T17:59:33Z",
-      "settlement:2023-11-19T17:59:33Z",
+      "enactment:2024-01-03T15:20:02Z",
+      "settlement:2024-01-02T15:20:02Z",
       "source:docs.vega.xyz"
      ],
      "priceMonitoringParameters": {
@@ -116,8 +120,8 @@
      }
     }
    },
-   "closingTimestamp": 1700416773,
-   "enactmentTimestamp": 1700503173
+   "closingTimestamp": 1704208802,
+   "enactmentTimestamp": 1704295202
   }
  }
 }'

--- a/versioned_docs/version-v0.73/tutorials/proposals/_generated-proposals/_newSuccessorMarket_json.md
+++ b/versioned_docs/version-v0.73/tutorials/proposals/_generated-proposals/_newSuccessorMarket_json.md
@@ -8,6 +8,10 @@
   "terms": {
     "newMarket": {
       "changes": {
+        "successor": {
+          "parentMarketId": "marketid",
+          "insurancePoolFraction": "1"
+        },
         "linearSlippageFactor": "0.001",
         "quadraticSlippageFactor": "0",
         "decimalPlaces": "5",
@@ -77,8 +81,8 @@
           }
         },
         "metadata": [
-          "enactment:2023-11-20T17:59:33Z",
-          "settlement:2023-11-19T17:59:33Z",
+          "enactment:2024-01-03T15:20:02Z",
+          "settlement:2024-01-02T15:20:02Z",
           "source:docs.vega.xyz"
         ],
         "priceMonitoringParameters": {
@@ -115,8 +119,8 @@
         }
       }
     },
-    "closingTimestamp": 1700416773,
-    "enactmentTimestamp": 1700503173
+    "closingTimestamp": 1704208802,
+    "enactmentTimestamp": 1704295202
   }
 }
 ```

--- a/versioned_docs/version-v0.73/tutorials/proposals/_generated-proposals/_newSuccessorMarket_win.md
+++ b/versioned_docs/version-v0.73/tutorials/proposals/_generated-proposals/_newSuccessorMarket_win.md
@@ -10,6 +10,10 @@ vegawallet.exe transaction send --wallet YOUR_WALLETNAME --pubkey YOUR_PUBLIC_KE
  \"terms\": {^
   \"newMarket\": {^
    \"changes\": {^
+    \"successor\": {^
+     \"parentMarketId\": \"marketid\",^
+     \"insurancePoolFraction\": \"1\"^
+    },^
     \"linearSlippageFactor\": \"0.001\",^
     \"quadraticSlippageFactor\": \"0\",^
     \"decimalPlaces\": \"5\",^
@@ -79,8 +83,8 @@ vegawallet.exe transaction send --wallet YOUR_WALLETNAME --pubkey YOUR_PUBLIC_KE
      }^
     },^
     \"metadata\": [^
-     \"enactment:2023-11-20T17:59:33Z\",^
-     \"settlement:2023-11-19T17:59:33Z\",^
+     \"enactment:2024-01-03T15:20:02Z\",^
+     \"settlement:2024-01-02T15:20:02Z\",^
      \"source:docs.vega.xyz\"^
     ],^
     \"priceMonitoringParameters\": {^
@@ -117,8 +121,8 @@ vegawallet.exe transaction send --wallet YOUR_WALLETNAME --pubkey YOUR_PUBLIC_KE
     }^
    }^
   },^
-  \"closingTimestamp\": 1700416773,^
-  \"enactmentTimestamp\": 1700503173^
+  \"closingTimestamp\": 1704208802,^
+  \"enactmentTimestamp\": 1704295202^
  }^
 }^
 }"


### PR DESCRIPTION
Fix #853

- Remove automatic proposal generation on build
- Add missing fields back to successor template
- Regenerate successor market proposals
