### PR TITLE
feat: Update operator docs

### DIFF
--- a/docs/node-operators/get-started/setup-datanode.md
+++ b/docs/node-operators/get-started/setup-datanode.md
@@ -110,10 +110,10 @@ New Value:
 max_locks_per_transaction = 256
 ```
 
-This value may change in future to bigger number. It depends on the traffic on the network. See [the official docs](https://postgresqlco.nf/doc/en/param/max_locks_per_transaction/) for reference.
+This value may change in the future to a bigger number, depending on the network traffic. See the [Postgres docs ↗](https://postgresqlco.nf/doc/en/param/max_locks_per_transaction/) for reference.
 
-:::note
-When the value is too low, you may end with the following error: `ERROR: out of shared memory (SQLSTATE 53200)`.
+:::note Error state
+When the value is too low, you may see the following error: `ERROR: out of shared memory (SQLSTATE 53200)`.
 :::
 
 #### Work mem

--- a/docs/node-operators/get-started/setup-datanode.md
+++ b/docs/node-operators/get-started/setup-datanode.md
@@ -40,6 +40,7 @@ docker run -d \
     -v $POSTGRES_PATH/data:/var/lib/postgresql/data \
     timescale/timescaledb:2.8.0-pg14 \
         -c "max_connections=50" \
+        -c "max_locks_per_transaction=256" \
         -c "log_destination=stderr" \
         -c "work_mem=5MB" \
         -c "huge_pages=off" \
@@ -100,6 +101,20 @@ huge_pages = off
 ```
 
 The default value of the `huge_pages` config is `try`. Setting it to `off` usually reduces the RAM usage, however, it increases the CPU usage on the machine.
+
+#### Max locks per transaction
+
+New Value:
+
+```conf
+max_locks_per_transaction = 256
+```
+
+This value may change in future to bigger number. It depends on the traffic on the network. See [the official docs](https://postgresqlco.nf/doc/en/param/max_locks_per_transaction/) for reference.
+
+:::note
+When the value is too low, you may end with the following error: `ERROR: out of shared memory (SQLSTATE 53200)`.
+:::
 
 #### Work mem
 

--- a/docs/node-operators/how-to/solve-frequent-issues.md
+++ b/docs/node-operators/how-to/solve-frequent-issues.md
@@ -240,3 +240,19 @@ stopSignalTimeoutSeconds = 15
     name = "vega-linux-amd64.zip"
     binaryName = "vega"
 ```
+
+## Problem: Error in the data-node `ERROR: out of shared memory (SQLSTATE 53200)`
+
+The error means a data node sent query to the data base that locks more items in single transaction than your PostgreSQL config allows.
+
+You can usually see the simillar error in the data node logs:
+
+```
+vega data node stopped with error: failed to flush subscriber:flushing ledger: failed to copy "ledger" entries into database: ERROR: out of shared memory (SQLSTATE 53200)
+```
+
+### Solution: Update the max_locks_per_transaction parameter in the PostgreSQL config
+
+1. Update your PostgreSQL config file(usually the config is located at `cat /etc/postgresql/14/main/postgresql.conf`). Change the max_locks_per_transaction to a bigger number 256 or more.
+2. Restart your PostgreSQL server
+3. Start your data-node.

--- a/docs/node-operators/how-to/solve-frequent-issues.md
+++ b/docs/node-operators/how-to/solve-frequent-issues.md
@@ -241,11 +241,11 @@ stopSignalTimeoutSeconds = 15
     binaryName = "vega"
 ```
 
-## Problem: Error in the data-node `ERROR: out of shared memory (SQLSTATE 53200)`
+## Problem: Data node `ERROR: out of shared memory (SQLSTATE 53200)`
 
-The error means a data node sent query to the data base that locks more items in single transaction than your PostgreSQL config allows.
+The error means a data node sent a query to the database that locks more items in single transaction than your PostgreSQL config allows.
 
-You can usually see the simillar error in the data node logs:
+You can usually see a similar error in the data node logs:
 
 ```
 vega data node stopped with error: failed to flush subscriber:flushing ledger: failed to copy "ledger" entries into database: ERROR: out of shared memory (SQLSTATE 53200)
@@ -253,6 +253,6 @@ vega data node stopped with error: failed to flush subscriber:flushing ledger: f
 
 ### Solution: Update the max_locks_per_transaction parameter in the PostgreSQL config
 
-1. Update your PostgreSQL config file(usually the config is located at `cat /etc/postgresql/14/main/postgresql.conf`). Change the max_locks_per_transaction to a bigger number 256 or more.
+1. Update your PostgreSQL config file. This is usually the config is located at `cat /etc/postgresql/14/main/postgresql.conf`). Change the max_locks_per_transaction to a bigger number, such as 256 or higher.
 2. Restart your PostgreSQL server
-3. Start your data-node.
+3. Start your data node.

--- a/versioned_docs/version-v0.73/node-operators/get-started/setup-datanode.md
+++ b/versioned_docs/version-v0.73/node-operators/get-started/setup-datanode.md
@@ -248,6 +248,29 @@ vega datanode start --home=$YOUR_DATANODE_HOME_PATH
 ```
 4. Now start the non validator node and confirm that both apps are running and you can see the block height increasing on both. 
 
+:::warning
+
+We found a bug in the vega network that crashed the mainnet network at block `26439343`. This makes replaying chain from block 0 more complicated. 
+
+```
+cannot unregister order with potential sell + size changes < 0
+```
+
+When your node failed with the above error message the procedure is following:
+
+1. Rollback tendermint block: `vega tm rollback --home <tendermint_home>
+2. Download the [v0.73.6-patch.1](https://github.com/vegaprotocol/vega/releases/tag/v0.73.6-patch.1) binary
+3. Start your node with downloaded binary from block `26439116`, e.g: with the following flag: `--snapshot.load-from-block-height 26439116`
+4. The binary will apply some fixes to the broken transactions, but  the node will fail with the following error: `panic: cannot unregister order with potential sell + size change < 0`.
+5. Reply steps 1-3, but use the [v0.73.6-patch.2](https://github.com/vegaprotocol/vega/releases/tag/v0.73.6-patch.2) binary.
+
+**It is an important to let binary fail with the `v0.73.6-patch.1` binary, or you won't be able to move your node forward!.**
+
+After v0.73.6-patch.2 your node will normally continue replaying.
+:::
+
+
+
 
 ## Starting the data node from network history
 

--- a/versioned_docs/version-v0.73/node-operators/get-started/setup-datanode.md
+++ b/versioned_docs/version-v0.73/node-operators/get-started/setup-datanode.md
@@ -101,6 +101,22 @@ huge_pages = off
 
 The default value of the `huge_pages` config is `try`. Setting it to `off` usually reduces the RAM usage, however, it increases the CPU usage on the machine.
 
+
+#### Max locks per transaction
+
+New Value:
+
+```conf
+max_locks_per_transaction = 256
+```
+
+This value may change in future to bigger number. It depends on the traffic on the network. See [the official docs](https://postgresqlco.nf/doc/en/param/max_locks_per_transaction/) for reference.
+
+:::note
+When the value is too low, you may end with the following error: `ERROR: out of shared memory (SQLSTATE 53200)`.
+:::
+
+
 #### Work mem
 
 New value:
@@ -142,6 +158,8 @@ New value:
 ```conf
 shared_memory_type = sysv
 ```
+
+
 
 The two above parameters determine how your operating system manages the shared memory.
 

--- a/versioned_docs/version-v0.73/node-operators/get-started/setup-datanode.md
+++ b/versioned_docs/version-v0.73/node-operators/get-started/setup-datanode.md
@@ -110,10 +110,10 @@ New Value:
 max_locks_per_transaction = 256
 ```
 
-This value may change in future to bigger number. It depends on the traffic on the network. See [the official docs](https://postgresqlco.nf/doc/en/param/max_locks_per_transaction/) for reference.
+This value may change in the future to a bigger number, depending on the network traffic. See the [Postgres docs ↗](https://postgresqlco.nf/doc/en/param/max_locks_per_transaction/) for reference.
 
-:::note
-When the value is too low, you may end with the following error: `ERROR: out of shared memory (SQLSTATE 53200)`.
+:::note Error state
+When the value is too low, you may see the following error: `ERROR: out of shared memory (SQLSTATE 53200)`.
 :::
 
 #### Work mem
@@ -249,23 +249,19 @@ vega datanode start --home=$YOUR_DATANODE_HOME_PATH
 
 :::warning
 
-We found a bug in the vega network that crashed the mainnet network at block `26439343`. This makes replaying chain from block 0 more complicated. 
+A bug on the Vega network that crashed the mainnet network at block `26439343`. This makes replaying chain from block 0 more complicated. 
 
-```
-cannot unregister order with potential sell + size changes < 0
-```
+If your node fails with this error message, follow the procedure described below: `cannot unregister order with potential sell + size changes < 0`
 
-When your node failed with the above error message the procedure is following:
-
-1. Rollback tendermint block: `vega tm rollback --home <tendermint_home>
-2. Download the [v0.73.6-patch.1](https://github.com/vegaprotocol/vega/releases/tag/v0.73.6-patch.1) binary
+1. Roll back tendermint block: `vega tm rollback --home <tendermint_home>`
+2. Download the [v0.73.6-patch.1 ↗](https://github.com/vegaprotocol/vega/releases/tag/v0.73.6-patch.1) binary
 3. Start your node with downloaded binary from block `26439116`, e.g: with the following flag: `--snapshot.load-from-block-height 26439116`
-4. The binary will apply some fixes to the broken transactions, but  the node will fail with the following error: `panic: cannot unregister order with potential sell + size change < 0`.
-5. Reply steps 1-3, but use the [v0.73.6-patch.2](https://github.com/vegaprotocol/vega/releases/tag/v0.73.6-patch.2) binary.
+4. The binary will apply some fixes to the broken transactions, but the node will fail with the following error: `panic: cannot unregister order with potential sell + size change < 0`.
+5. Reply steps 1-3, but use the [v0.73.6-patch.2 ↗](https://github.com/vegaprotocol/vega/releases/tag/v0.73.6-patch.2) binary.
 
-**It is an important to let binary fail with the `v0.73.6-patch.1` binary, or you won't be able to move your node forward!.**
+**It is essential to let the binary fail with the `v0.73.6-patch.1` binary, or you won't be able to move your node forward!**
 
-After v0.73.6-patch.2 your node will normally continue replaying.
+After `v0.73.6-patch.2` your node will continue replaying normally.
 :::
 
 

--- a/versioned_docs/version-v0.73/node-operators/get-started/setup-datanode.md
+++ b/versioned_docs/version-v0.73/node-operators/get-started/setup-datanode.md
@@ -40,6 +40,7 @@ docker run -d \
     -v $POSTGRES_PATH/data:/var/lib/postgresql/data \
     timescale/timescaledb:2.8.0-pg14 \
         -c "max_connections=50" \
+        -c "max_locks_per_transaction=256" \
         -c "log_destination=stderr" \
         -c "work_mem=5MB" \
         -c "huge_pages=off" \
@@ -101,7 +102,6 @@ huge_pages = off
 
 The default value of the `huge_pages` config is `try`. Setting it to `off` usually reduces the RAM usage, however, it increases the CPU usage on the machine.
 
-
 #### Max locks per transaction
 
 New Value:
@@ -115,7 +115,6 @@ This value may change in future to bigger number. It depends on the traffic on t
 :::note
 When the value is too low, you may end with the following error: `ERROR: out of shared memory (SQLSTATE 53200)`.
 :::
-
 
 #### Work mem
 

--- a/versioned_docs/version-v0.73/node-operators/how-to/solve-frequent-issues.md
+++ b/versioned_docs/version-v0.73/node-operators/how-to/solve-frequent-issues.md
@@ -240,3 +240,19 @@ stopSignalTimeoutSeconds = 15
     name = "vega-linux-amd64.zip"
     binaryName = "vega"
 ```
+
+## Problem: Error in the data-node `ERROR: out of shared memory (SQLSTATE 53200)`
+
+The error means a data node sent query to the data base that locks more items in single transaction than your PostgreSQL config allows.
+
+You can usually see the simillar error in the data node logs:
+
+```
+vega data node stopped with error: failed to flush subscriber:flushing ledger: failed to copy "ledger" entries into database: ERROR: out of shared memory (SQLSTATE 53200)
+```
+
+### Solution: Update the max_locks_per_transaction parameter in the PostgreSQL config
+
+1. Update your PostgreSQL config file(usually the config is located at `cat /etc/postgresql/14/main/postgresql.conf`). Change the max_locks_per_transaction to a bigger number 256 or more.
+2. Restart your PostgreSQL server
+3. Start your data-node.

--- a/versioned_docs/version-v0.73/node-operators/how-to/solve-frequent-issues.md
+++ b/versioned_docs/version-v0.73/node-operators/how-to/solve-frequent-issues.md
@@ -256,3 +256,14 @@ vega data node stopped with error: failed to flush subscriber:flushing ledger: f
 1. Update your PostgreSQL config file(usually the config is located at `cat /etc/postgresql/14/main/postgresql.conf`). Change the max_locks_per_transaction to a bigger number 256 or more.
 2. Restart your PostgreSQL server
 3. Start your data-node.
+
+## Problem: CONSENSUS FAILURE at block `26439343`
+
+Your node may fail with the following error: `panic: cannot unregister order with potential sell + size change < 0` at block `26439343`.
+If block is different, this is a different issue.
+
+There was a bug in the mainnet that crashed the network. 
+
+### Solution: Apply patches to the mainnet network
+
+See the following procedure: [Apply patches for the consensus failure at block 26439343](../get-started/setup-datanode.md##starting-the-data-node-from-block-0).

--- a/versioned_docs/version-v0.73/node-operators/how-to/solve-frequent-issues.md
+++ b/versioned_docs/version-v0.73/node-operators/how-to/solve-frequent-issues.md
@@ -241,11 +241,11 @@ stopSignalTimeoutSeconds = 15
     binaryName = "vega"
 ```
 
-## Problem: Error in the data-node `ERROR: out of shared memory (SQLSTATE 53200)`
+## Problem: Data node `ERROR: out of shared memory (SQLSTATE 53200)`
 
-The error means a data node sent query to the data base that locks more items in single transaction than your PostgreSQL config allows.
+The error means a data node sent a query to the database that locks more items in single transaction than your PostgreSQL config allows.
 
-You can usually see the simillar error in the data node logs:
+You can usually see a similar error in the data node logs:
 
 ```
 vega data node stopped with error: failed to flush subscriber:flushing ledger: failed to copy "ledger" entries into database: ERROR: out of shared memory (SQLSTATE 53200)
@@ -253,16 +253,16 @@ vega data node stopped with error: failed to flush subscriber:flushing ledger: f
 
 ### Solution: Update the max_locks_per_transaction parameter in the PostgreSQL config
 
-1. Update your PostgreSQL config file(usually the config is located at `cat /etc/postgresql/14/main/postgresql.conf`). Change the max_locks_per_transaction to a bigger number 256 or more.
+1. Update your PostgreSQL config file, usually the config is located at `cat /etc/postgresql/14/main/postgresql.conf`. Change the `max_locks_per_transaction` to a bigger number, such as 256 or more.
 2. Restart your PostgreSQL server
-3. Start your data-node.
+3. Start your data node.
 
 ## Problem: CONSENSUS FAILURE at block `26439343`
 
 Your node may fail with the following error: `panic: cannot unregister order with potential sell + size change < 0` at block `26439343`.
-If block is different, this is a different issue.
+If the block is different, this is a different issue.
 
-There was a bug in the mainnet that crashed the network. 
+There was a mainnet bug that crashed the network. 
 
 ### Solution: Apply patches to the mainnet network
 


### PR DESCRIPTION
# Changes

1. Mark the `max_locks_per_transaction` parameter as required to change in the PostgreSQL prepare docs
2. Add frequent issues related to the above parameter.
3. Add info about patches required for the consensus failure at block 26439343