### PR TITLE
fix: improve build script that inserts hide_send_buttons

### DIFF
--- a/scripts/build-post-fix-generated.sh
+++ b/scripts/build-post-fix-generated.sh
@@ -1,14 +1,30 @@
 #!/usr/bin/env bash
+hide_send_button() {
+    local file_path="$1"
+    local line_to_add="hide_send_button: true"
+
+    # Check if the line already exists in the file
+    if ! grep -qF -- "$line_to_add" "$file_path"; then
+        echo "Add $line_to_add to $file_path"
+        # If the line does not exist, insert it at the second line of the file
+        sed -i "-E" "2i\\
+$line_to_add
+        " "$file_path"
+    fi
+}
 
 find 'specs' -name '*_temp.json' -exec rm {} +
 
 echo "- REST: Hide submit buttons for observe endpoints"
-find "docs/api/rest/data-v2/" -name "trading-data-service-observe-*.mdx" -exec sed -i -E 's/hide_title: true/hide_title: true\r\nhide_send_button: true/g' {} +
-#find "versioned_docs" -name "trading-data-service-observe-*.mdx" -exec sed -i -E 's/hide_title: true/hide_title: true\r\nhide_send_button: true/g' {} +
+find "docs/api/rest/data-v2/" -name "trading-data-service-observe-*.mdx" | while read -r file; do hide_send_button "$file"; done
+find "versioned_docs" -name "trading-data-service-observe-*.mdx" | while read -r file; do hide_send_button "$file"; done
 
 echo "- REST: Hide submit buttons for export ledger entries endpoint"
-find "docs/api/rest/data-v2/" -name "trading-data-service-export-ledger-entries.api.mdx" -exec sed -i -E 's/hide_title: true/hide_title: true\r\nhide_send_button: true/g' {} +
-find "versioned_docs" -name "trading-data-service-export-ledger-entries.api.mdx" -exec sed -i -E 's/hide_title: true/hide_title: true\r\nhide_send_button: true/g' {} +
+find "docs/api/rest/data-v2/" -name "trading-data-service-export-ledger-entries.api.mdx" | while read -r file; do hide_send_button "$file"; done 
+find "versioned_docs" -name "trading-data-service-export-ledger-entries.api.mdx" | while read -r file; do hide_send_button "$file"; done 
+
+echo "- REST: Hide submit buttons for mainnet core state api"
+find "versioned_docs" -name "core-service-*.mdx" | while read -r file; do hide_send_button "$file"; done 
 
 echo "- REST: Remove indexes (todo: fix hardcoded version)"
 find 'versioned_docs/version-v0.73/api/rest/' -name '*-service.mdx' -exec rm {} +

--- a/versioned_docs/version-v0.73/api/rest/core/core-service-check-raw-transaction.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/core/core-service-check-raw-transaction.api.mdx
@@ -1,4 +1,5 @@
 ---
+hide_send_button: true
 id: core-service-check-raw-transaction
 title: "Check raw transaction"
 description: "Send a pre-serialised transaction containing a command to the network to be checked, but then not added to the chain's mempool.

--- a/versioned_docs/version-v0.73/api/rest/core/core-service-check-transaction.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/core/core-service-check-transaction.api.mdx
@@ -1,4 +1,5 @@
 ---
+hide_send_button: true
 id: core-service-check-transaction
 title: "Check transaction"
 description: "Send a signed transaction containing a command to the network to be checked, but not added to the chain's mempool.

--- a/versioned_docs/version-v0.73/api/rest/core/core-service-get-spam-statistics.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/core/core-service-get-spam-statistics.api.mdx
@@ -1,4 +1,5 @@
 ---
+hide_send_button: true
 id: core-service-get-spam-statistics
 title: "Get Spam statistics"
 description: "Get the spam statistics for a given party."

--- a/versioned_docs/version-v0.73/api/rest/core/core-service-get-vega-time.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/core/core-service-get-vega-time.api.mdx
@@ -1,4 +1,5 @@
 ---
+hide_send_button: true
 id: core-service-get-vega-time
 title: "Vega time"
 description: "Get current Vega time"

--- a/versioned_docs/version-v0.73/api/rest/core/core-service-last-block-height.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/core/core-service-last-block-height.api.mdx
@@ -1,4 +1,5 @@
 ---
+hide_send_button: true
 id: core-service-last-block-height
 title: "Blockchain height"
 description: "Get the height of the last tendermint block"

--- a/versioned_docs/version-v0.73/api/rest/core/core-service-observe-event-bus.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/core/core-service-observe-event-bus.api.mdx
@@ -1,4 +1,5 @@
 ---
+hide_send_button: true
 id: core-service-observe-event-bus
 title: "Events subscription"
 description: "Subscribe to a stream of events from the core"

--- a/versioned_docs/version-v0.73/api/rest/core/core-service-statistics.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/core/core-service-statistics.api.mdx
@@ -1,4 +1,5 @@
 ---
+hide_send_button: true
 id: core-service-statistics
 title: "Statistics"
 description: "Get statistics on Vega"

--- a/versioned_docs/version-v0.73/api/rest/core/core-service-submit-raw-transaction.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/core/core-service-submit-raw-transaction.api.mdx
@@ -1,4 +1,5 @@
 ---
+hide_send_button: true
 id: core-service-submit-raw-transaction
 title: "Submit raw transaction"
 description: "Submit a pre-serialised signed transaction containing a command to the network to be executed, such that if the submission is successful then it will be included in the chain's mempool.

--- a/versioned_docs/version-v0.73/api/rest/core/core-service-submit-transaction.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/core/core-service-submit-transaction.api.mdx
@@ -1,4 +1,5 @@
 ---
+hide_send_button: true
 id: core-service-submit-transaction
 title: "Submit transaction"
 description: "Submit a signed transaction to the network containing a command to be executed such that if the submission is successful then it will be included in the chain's mempool.

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-accounts.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-accounts.api.mdx
@@ -1,5 +1,5 @@
 ---
-        hide_send_button: true
+hide_send_button: true
 id: trading-data-service-observe-accounts
 title: "Accounts subscription"
 description: "Subscribe to a stream of accounts"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-accounts.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-accounts.api.mdx
@@ -1,4 +1,5 @@
 ---
+        hide_send_button: true
 id: trading-data-service-observe-accounts
 title: "Accounts subscription"
 description: "Subscribe to a stream of accounts"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-candle-data.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-candle-data.api.mdx
@@ -1,5 +1,5 @@
 ---
-        hide_send_button: true
+hide_send_button: true
 id: trading-data-service-observe-candle-data
 title: "Observe candle data"
 description: "Subscribe to a stream of candle updates"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-candle-data.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-candle-data.api.mdx
@@ -1,4 +1,5 @@
 ---
+        hide_send_button: true
 id: trading-data-service-observe-candle-data
 title: "Observe candle data"
 description: "Subscribe to a stream of candle updates"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-event-bus.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-event-bus.api.mdx
@@ -1,4 +1,5 @@
 ---
+        hide_send_button: true
 id: trading-data-service-observe-event-bus
 title: "Observe event bus"
 description: "Subscribe to a stream of events from the core"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-event-bus.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-event-bus.api.mdx
@@ -1,5 +1,5 @@
 ---
-        hide_send_button: true
+hide_send_button: true
 id: trading-data-service-observe-event-bus
 title: "Observe event bus"
 description: "Subscribe to a stream of events from the core"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-governance.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-governance.api.mdx
@@ -1,4 +1,5 @@
 ---
+        hide_send_button: true
 id: trading-data-service-observe-governance
 title: "Observe governance"
 description: "Subscribe to a stream of updates to governance proposals"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-governance.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-governance.api.mdx
@@ -1,5 +1,5 @@
 ---
-        hide_send_button: true
+hide_send_button: true
 id: trading-data-service-observe-governance
 title: "Observe governance"
 description: "Subscribe to a stream of updates to governance proposals"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-ledger-movements.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-ledger-movements.api.mdx
@@ -1,5 +1,5 @@
 ---
-        hide_send_button: true
+hide_send_button: true
 id: trading-data-service-observe-ledger-movements
 title: "Observe ledger movements"
 description: "Subscribe to a stream of transfer responses"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-ledger-movements.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-ledger-movements.api.mdx
@@ -1,4 +1,5 @@
 ---
+        hide_send_button: true
 id: trading-data-service-observe-ledger-movements
 title: "Observe ledger movements"
 description: "Subscribe to a stream of transfer responses"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-liquidity-provisions.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-liquidity-provisions.api.mdx
@@ -1,5 +1,5 @@
 ---
-        hide_send_button: true
+hide_send_button: true
 id: trading-data-service-observe-liquidity-provisions
 title: "Observe liquidity provisions"
 description: "Subscribe to a stream of liquidity provision events for a given market and party"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-liquidity-provisions.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-liquidity-provisions.api.mdx
@@ -1,4 +1,5 @@
 ---
+        hide_send_button: true
 id: trading-data-service-observe-liquidity-provisions
 title: "Observe liquidity provisions"
 description: "Subscribe to a stream of liquidity provision events for a given market and party"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-margin-levels.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-margin-levels.api.mdx
@@ -1,5 +1,5 @@
 ---
-        hide_send_button: true
+hide_send_button: true
 id: trading-data-service-observe-margin-levels
 title: "Observe margin levels"
 description: "Subscribe to a stream of margin levels updates"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-margin-levels.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-margin-levels.api.mdx
@@ -1,4 +1,5 @@
 ---
+        hide_send_button: true
 id: trading-data-service-observe-margin-levels
 title: "Observe margin levels"
 description: "Subscribe to a stream of margin levels updates"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-markets-data.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-markets-data.api.mdx
@@ -1,4 +1,5 @@
 ---
+        hide_send_button: true
 id: trading-data-service-observe-markets-data
 title: "Observe markets data"
 description: "Subscribe to a stream of data about a given market"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-markets-data.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-markets-data.api.mdx
@@ -1,5 +1,5 @@
 ---
-        hide_send_button: true
+hide_send_button: true
 id: trading-data-service-observe-markets-data
 title: "Observe markets data"
 description: "Subscribe to a stream of data about a given market"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-markets-depth-updates.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-markets-depth-updates.api.mdx
@@ -1,5 +1,5 @@
 ---
-        hide_send_button: true
+hide_send_button: true
 id: trading-data-service-observe-markets-depth-updates
 title: "Observe markets depth updates"
 description: "Subscribe to a stream of updates on market depth for a given market"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-markets-depth-updates.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-markets-depth-updates.api.mdx
@@ -1,4 +1,5 @@
 ---
+        hide_send_button: true
 id: trading-data-service-observe-markets-depth-updates
 title: "Observe markets depth updates"
 description: "Subscribe to a stream of updates on market depth for a given market"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-markets-depth.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-markets-depth.api.mdx
@@ -1,4 +1,5 @@
 ---
+        hide_send_button: true
 id: trading-data-service-observe-markets-depth
 title: "Observe markets depth"
 description: "Subscribe to a stream of the latest market depth for a given market"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-markets-depth.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-markets-depth.api.mdx
@@ -1,5 +1,5 @@
 ---
-        hide_send_button: true
+hide_send_button: true
 id: trading-data-service-observe-markets-depth
 title: "Observe markets depth"
 description: "Subscribe to a stream of the latest market depth for a given market"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-orders.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-orders.api.mdx
@@ -1,4 +1,5 @@
 ---
+        hide_send_button: true
 id: trading-data-service-observe-orders
 title: "Observe orders"
 description: "Subscribe to a stream of orders"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-orders.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-orders.api.mdx
@@ -1,5 +1,5 @@
 ---
-        hide_send_button: true
+hide_send_button: true
 id: trading-data-service-observe-orders
 title: "Observe orders"
 description: "Subscribe to a stream of orders"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-positions.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-positions.api.mdx
@@ -1,5 +1,5 @@
 ---
-        hide_send_button: true
+hide_send_button: true
 id: trading-data-service-observe-positions
 title: "Observe positions"
 description: "Subscribe to a stream of position updates. The first messages sent through the stream will contain

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-positions.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-positions.api.mdx
@@ -1,4 +1,5 @@
 ---
+        hide_send_button: true
 id: trading-data-service-observe-positions
 title: "Observe positions"
 description: "Subscribe to a stream of position updates. The first messages sent through the stream will contain

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-trades.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-trades.api.mdx
@@ -1,5 +1,5 @@
 ---
-        hide_send_button: true
+hide_send_button: true
 id: trading-data-service-observe-trades
 title: "Observe trades"
 description: "Subscribe to a stream of trades, optionally filtered by party/market"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-trades.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-trades.api.mdx
@@ -1,4 +1,5 @@
 ---
+        hide_send_button: true
 id: trading-data-service-observe-trades
 title: "Observe trades"
 description: "Subscribe to a stream of trades, optionally filtered by party/market"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-votes.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-votes.api.mdx
@@ -1,4 +1,5 @@
 ---
+        hide_send_button: true
 id: trading-data-service-observe-votes
 title: "Observe votes"
 description: "Subscribe to a stream of votes cast on a given proposal, or by all votes made by a given party"

--- a/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-votes.api.mdx
+++ b/versioned_docs/version-v0.73/api/rest/data-v2/trading-data-service-observe-votes.api.mdx
@@ -1,5 +1,5 @@
 ---
-        hide_send_button: true
+hide_send_button: true
 id: trading-data-service-observe-votes
 title: "Observe votes"
 description: "Subscribe to a stream of votes cast on a given proposal, or by all votes made by a given party"


### PR DESCRIPTION
improve hiding API send buttons 

The build script previously blindly inserted hide_send_button, which was a problem when it was duplicated. Now it
actually checks if the line is there, and only inserts it if it isn't. 

- Hide send button on mainnet core state APIs (as none are exposed)
