### PR TITLE
Fix client side navigation error

### DIFF
--- a/docs/concepts/trading-on-vega/margin.md
+++ b/docs/concepts/trading-on-vega/margin.md
@@ -31,7 +31,7 @@ When placing order on a market, you can set your margin factor when using isolat
 :::tip Try it out
 [Use Console ↗](https://console.fairground.wtf) to trade with cross margin or isolated margin. The leverage slider lets you set your isolated margin level.
 
-Or [use the update margin mode command](../../api/grpc/vega/commands/v1/commands.proto.mdx) to submit the transaction yourself.
+Or [use the update margin mode command](../../api/grpc/vega/commands/v1/commands.proto.mdx#updatemarginmode) to submit the transaction yourself.
 
 Switching between modes may change your margin requirements.
 :::

--- a/src/components/NetworkParameter.js
+++ b/src/components/NetworkParameter.js
@@ -44,10 +44,13 @@ export default function NetworkParameter (props) {
     data = dataForNetwork[vega_network].buildTime
   }
 
-  useEffect(async () => {
-    // This is only triggered on client side render, and will be blocked
-    // from fetching multiple times
-    await fetchData(vega_network)
+  useEffect(() => {
+    const asyncFetch = async () => {
+      // This is only triggered on client side render, and will be blocked
+      // from fetching multiple times
+      await fetchData(vega_network)
+    }
+    asyncFetch()
   }, [vega_network])
 
   if (data) {


### PR DESCRIPTION
After upgrading docusaurus, the way the NetworkParameter component was waiting for data to be fetch is no longer valid.
This PR adds a small fudge to keep the old behaviour with basically the same code
