### PR TITLE
chore: update release summary version numbers

### DIFF
--- a/versioned_docs/version-v0.73/releases/overview.md
+++ b/versioned_docs/version-v0.73/releases/overview.md
@@ -22,16 +22,10 @@ The Vega core software is public and open source under the [AGPL ↗](https://ww
 ### Release version 0.73.14 (patch) | 2024-02-06
 Version 0.73.14 was released by the validators to mainnet on 06 February, 2024.
 
-This release contained two bug fixes: 
+The version contained the following critical bug fixes:
 
-* In a situation where the mark-to-market calculation included data for a party with no position, the code would raise a panic, which would then cause a node to fail.
+* In a situation where the mark-to-market calculation included data for a party with no position, the code would raise a panic, which would then cause a node to fail. This issue was a patch fix in responce to the following network outage [mainnet incdent ↗](https://medium.com/vegaprotocol/incident-report-network-outage-e60376912790)
 * In some circumstances, PnL was incorrectly displayed by the API. This was resolved in issue [10568 ↗](https://github.com/vegaprotocol/vega/issues/10568)
-
-### Release version 0.73.13 (patch) | 2024-02-06
-Version 0.73.13 was released by the validators to mainnet on 06 February, 2024.
-
-The version contained the following critical bug fix:
-
 * During the governance voted termination of the LINK/USDT market on mainnet a particular edge case bug was identified. This is where the TWAP calculation for the internal data point, happening at the end of a funding period, can be incorrect. This led to some balances being incorrect during the funding payments. The calculation error has been resolved in the issue [10520 ↗](https://github.com/vegaprotocol/vega/issues/10520).
 
 ### Release versions 0.73.11 and 0.73.12 (patch) combined | 2024-01-12


### PR DESCRIPTION
As the patch version that went out for the network outage didnt up the semver version this PR combines the releases into one entry for that day