### PR TITLE
chore: update 0.74 testnet release notes

### DIFF
--- a/docs/releases/overview.md
+++ b/docs/releases/overview.md
@@ -22,7 +22,7 @@ The Vega core software is public and open source under the [AGPL ↗](https://ww
 ## Pre-release version 0.74 | 2024-01-24
 This version was released to the Vega testnet on 24 January 2024.
 
-This pre-release contains several new features for the Palazzo milestone, including isolated margin, batch proposals, Ethereum RPC and EVM based data sources and a new mark price and price for perps funding TWAP methodology.
+This pre-release contains several new features for the Palazzo milestone, including isolated margin, batch proposals, Ethereum RPC and EVM based data sources, new mark price and perps funding TWAP methodology, LP fee setting improvements and team games and party profile updates.
 
 ### Breaking changes
 
@@ -34,6 +34,24 @@ This pre-release contains several new features for the Palazzo milestone, includ
  - Commands `tm` and `tendermint` are deprecated in favour of `cometbft`. This has been completed in [issue 10000 ↗](https://github.com/vegaprotocol/vega/issues/10000)
 
 ### New Features
+
+This release brings in a number of new network parameters. The below table details the parameters, default values and the associated specs should the community wish to change these post deployment.
+
+
+| Network parameter    | Default value | Feature |
+| -------------------- | ----- | ------------- |
+| blockchains.ethereumRpcAndEvmCompatDataSourcesConfig | {"configs":[{"network_id":"100","chain_id":"100","confirmations":3,"name":"Gnosis Chain"}]} | EVM RPC data sourcing [spec ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0087-EVMD-eth-rpc-and-evm-data-source.md) |
+| network.internalCompositePriceUpdateFrequency | 5s | Mark price [spec ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0009-MRKP-mark_price.md) |
+| spam.protection.max.updatePartyProfile | 5 | Teams and games [spec ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0062-SPAM-spam_protection.md) |
+| spam.protection.updatePartyProfile.min.funds | 10 | Teams and games [spec ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0062-SPAM-spam_protection.md) |
+| spam.protection.referralSet.min.funds | 10 | Teams and games [spec ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0062-SPAM-spam_protection.md) |
+| transfer.fee.maxQuantumAmount | 1 | Transfer fee improvements [spec ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0057-TRAN-transfers.md) |
+| transfer.feeDiscountDecayFraction | 0.5 | Transfer fee improvements [spec ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0057-TRAN-transfers.md) |
+| transfer.feeDiscountMinimumTrackedAmount | 0.001 | Transfer fee improvements [spec ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0057-TRAN-transfers.md) |
+
+> [!IMPORTANT]
+> These default values are subject to be different in mainnet, therefore, anyone building on top of these values should reference the mainnet release notes when published.
+
 
 #### Isolated margin
 
@@ -48,7 +66,7 @@ To see lower level details of how the new isolated margin feature is designed ch
 
 A `BatchProposalSubmission` is a top-level proposal type that allows grouping several individual proposals into a single proposal. All changes will pass or fail governance voting together.
 
-The batch proposal is a wrapper containing one rationale (i.e. title and description) and one closing timestamp for the whole set, and a list of proposal submissions for each proposed change that omit certain fields. 
+The batch proposal is a wrapper containing one rationale (i.e. title and description) and one closing timestamp for the whole set, and a list of proposal submissions for each proposed change that omit certain fields.
 
 Any governance proposal can be included in a batch except proposals to *add* new assets.
 
@@ -74,10 +92,32 @@ To see lower level details of how the new mark price and price for perps funding
 
 Improvements have been made to how distressed parties are liquidated. Now new market proposals will need to include a liquidation strategy configuration.
 
-This configuration is used to allow the network to hold an active position on the market. Parties that are distressed, but previously couldn't be liquidated because there was insufficient volume on the book, will now be liquidated. In this process the party's position is transferred to the network party, and rather than dumping the distressed volume on the market, an inventory management strategy carries this out over time. 
+This configuration is used to allow the network to hold an active position on the market. Parties that are distressed, but previously couldn't be liquidated because there was insufficient volume on the book, will now be liquidated. In this process the party's position is transferred to the network party, and rather than dumping the distressed volume on the market, an inventory management strategy carries this out over time.
 
 This improvement has been added in [issue 9945 ↗](https://github.com/vegaprotocol/vega/issues/9945)
 
+#### Liquidity provider fee setting improvements
+
+There are three methods for setting the liquidity fee factor, with the default method being the current 'Marginal Cost method.' The liquidity fee setting mechanism is configured per market as part of the market proposal. Th two new methods are:
+
+**Stake-weighted-average method for setting the liquidity fee factor**
+
+The liquidity fee factor is set as the weighted average of the liquidity fee factors, with weights assigned based on the supplied stake from each liquidity provider, which can also account for the impact of one supplier's actions on others.
+
+**"Constant Liquidity Fee" Method**
+
+The liquidity fee factor is set to a constant directly as part of the market proposal.
+
+This has been implemented as per the [LP fee and rewards setting specification ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0042-LIQF-setting_fees_and_rewarding_lps.md)
+
+
+#### Teams games and party profiles
+
+A number of changes have been introduced to incentivise the use of Vega through rewards. Along with the referral program users will be able to create teams and incentivse use via reward structures. The team reward metrics and accounts have been implemented as per the [rewards specification ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0056-REWA-rewards_overview.md#team-reward-metrics).
+
+Changes have also been implemented to allow users to have an on-chain party profile allowing the creation of an alia and metadata for a given party.
+
+This has been implemented as per the [party profile specification ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0088-PPRF-party_profile.md)
 
 ### Pre-release version 0.73.12 (patch) | 2024-01-10
 Version 0.73.12 was released the Vega testnet on 10 January, 2024.

--- a/docs/releases/overview.md
+++ b/docs/releases/overview.md
@@ -104,7 +104,7 @@ There are three methods for setting the liquidity fee factor, with the default m
 
 The liquidity fee factor is set as the weighted average of the liquidity fee factors, with weights assigned based on the supplied stake from each liquidity provider, which can also account for the impact of one supplier's actions on others.
 
-**"Constant Liquidity Fee" Method**
+**"Constant liquidity fee" method**
 
 The liquidity fee factor is set to a constant directly as part of the market proposal.
 
@@ -113,9 +113,9 @@ This has been implemented as per the [LP fee and rewards setting specification �
 
 #### Teams games and party profiles
 
-A number of changes have been introduced to incentivise the use of Vega through rewards. Along with the referral program users will be able to create teams and incentivse use via reward structures. The team reward metrics and accounts have been implemented as per the [rewards specification ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0056-REWA-rewards_overview.md#team-reward-metrics).
+A number of changes have been introduced to incentivise the use of Vega through rewards. Along with the referral program users will be able to create teams and incentivise use via reward structures. The team reward metrics and accounts have been implemented as per the [rewards specification ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0056-REWA-rewards_overview.md#team-reward-metrics).
 
-Changes have also been implemented to allow users to have an on-chain party profile allowing the creation of an alia and metadata for a given party.
+Now, participants can also have an on-chain party profile allowing them to add an alias and metadata to a given party.
 
 This has been implemented as per the [party profile specification ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0088-PPRF-party_profile.md)
 

--- a/docs/releases/overview.md
+++ b/docs/releases/overview.md
@@ -50,7 +50,7 @@ This release brings in a number of new network parameters. The below table detai
 | transfer.feeDiscountMinimumTrackedAmount | 0.001 | Transfer fee improvements [spec ↗](https://github.com/vegaprotocol/specs/blob/palazzo/protocol/0057-TRAN-transfers.md) |
 
 > [!IMPORTANT]
-> These default values are subject to be different in mainnet, therefore, anyone building on top of these values should reference the mainnet release notes when published.
+> These default values are subject to be different in mainnet, therefore, anyone building on top of these values should reference the mainnet release notes when published. These values can be found in [this PR](https://github.com/vegaprotocol/vega/pull/10552)
 
 
 #### Isolated margin


### PR DESCRIPTION
This PR updates the 0.74 release summary notes to be in line with what will be published for mainnet