### PR TITLE
add release note for 0.74.4

### DIFF
--- a/versioned_docs/version-v0.74/releases/overview.md
+++ b/versioned_docs/version-v0.74/releases/overview.md
@@ -19,8 +19,8 @@ See the full release notes on [GitHub ↗](https://github.com/vegaprotocol/vega/
 ## Vega core software
 The Vega core software is public and open source under the [AGPL ↗](https://www.gnu.org/licenses/agpl-3.0.en.html) license, so you can both view the repository change logs, and refer here for summary release notes for each version that the validators use to run the Vega mainnet. Releases are listed with their semantic version number and the date the release was made available to mainnet validators.
 
-## Release version 0.74.4 | 2024-02-XX
-This version was released by the validators to mainnet on XX February 2024.
+## Release version 0.74.4 | 2024-02-23
+This version was released by the validators to mainnet on 23 February 2024.
 
 This release contains the changes to restore balances from manipulator withdrawals, as can be seen in the [release notes](https://github.com/vegaprotocol/vega/releases/tag/v0.74.4). It has been made available in response to the following [mainnet incident report ↗](https://medium.com/vegaprotocol/incident-report-network-outage-e60376912790).
 

--- a/versioned_docs/version-v0.74/releases/overview.md
+++ b/versioned_docs/version-v0.74/releases/overview.md
@@ -19,6 +19,11 @@ See the full release notes on [GitHub ↗](https://github.com/vegaprotocol/vega/
 ## Vega core software
 The Vega core software is public and open source under the [AGPL ↗](https://www.gnu.org/licenses/agpl-3.0.en.html) license, so you can both view the repository change logs, and refer here for summary release notes for each version that the validators use to run the Vega mainnet. Releases are listed with their semantic version number and the date the release was made available to mainnet validators.
 
+## Release version 0.74.4 | 2024-02-XX
+This version was released by the validators to mainnet on XX February 2024.
+
+This release contains the changes to restore balances from manipulator withdrawals, as can be seen in the [release notes](https://github.com/vegaprotocol/vega/releases/tag/v0.74.4). It has been made available in response to the following [mainnet incident report ↗](https://medium.com/vegaprotocol/incident-report-network-outage-e60376912790).
+
 ## Release version 0.74.3 | 2024-02-20
 This version was released by the validators to mainnet on 20 February 2024.
 


### PR DESCRIPTION
Adds release summary notes for the restoration of the manipulated balance in the following  [mainnet incident ↗](https://medium.com/vegaprotocol/incident-report-network-outage-e60376912790) report.