### PR TITLE
feat: update from and to blocks range in the arbitrum rpc query to hex ones

### DIFF
--- a/docs/node-operators/get-started/setup-validator.md
+++ b/docs/node-operators/get-started/setup-validator.md
@@ -247,7 +247,7 @@ To find the block span allowed by your RPC provider call the following query:
 curl https://RPC_URL_FOR_ARBITRUM \
   -X POST \
   -H "Content-Type: application/json" \
-  --data '{"method":"eth_getLogs","params":[{"address": "0xE4D5c6aE46ADFAF04313081e8C0052A30b6Dd724", "fromBlock": "207349352", "toBlock": "207349392"}],"id":1,"jsonrpc":"2.0"}'
+  --data '{"method":"eth_getLogs","params":[{"address": "0xE4D5c6aE46ADFAF04313081e8C0052A30b6Dd724", "fromBlock": "0xC5BE668", "toBlock": "0xC5BE6F4"}],"id":1,"jsonrpc":"2.0"}'
 ```
 
 Manipulate the `fromBlock` and `toBlock` values to find the correct allowed block range.

--- a/docs/node-operators/migration-guides/upgrade-node.md
+++ b/docs/node-operators/migration-guides/upgrade-node.md
@@ -56,7 +56,7 @@ To find the block span allowed by your RPC provider call the following query:
 curl https://RPC_URL_FOR_ARBITRUM \
   -X POST \
   -H "Content-Type: application/json" \
-  --data '{"method":"eth_getLogs","params":[{"address": "0xE4D5c6aE46ADFAF04313081e8C0052A30b6Dd724", "fromBlock": "207349352", "toBlock": "207349392"}],"id":1,"jsonrpc":"2.0"}'
+  --data '{"method":"eth_getLogs","params":[{"address": "0xE4D5c6aE46ADFAF04313081e8C0052A30b6Dd724", "fromBlock": "0xC5BE668", "toBlock": "0xC5BE6F4"}],"id":1,"jsonrpc":"2.0"}'
 ```
 
 Manipulate the `fromBlock` and `toBlock` values to find the correct allowed block range.

--- a/versioned_docs/version-v0.75/node-operators/migration-guides/upgrade-node.md
+++ b/versioned_docs/version-v0.75/node-operators/migration-guides/upgrade-node.md
@@ -56,7 +56,7 @@ To find the block span allowed by your RPC provider call the following query:
 curl https://RPC_URL_FOR_ARBITRUM \
   -X POST \
   -H "Content-Type: application/json" \
-  --data '{"method":"eth_getLogs","params":[{"address": "0xE4D5c6aE46ADFAF04313081e8C0052A30b6Dd724", "fromBlock": "207349352", "toBlock": "207349392"}],"id":1,"jsonrpc":"2.0"}'
+  --data '{"method":"eth_getLogs","params":[{"address": "0xE4D5c6aE46ADFAF04313081e8C0052A30b6Dd724", "fromBlock": "0xC5BE668", "toBlock": "0xC5BE6F4"}],"id":1,"jsonrpc":"2.0"}'
 ```
 
 Manipulate the `fromBlock` and `toBlock` values to find the correct allowed block range.


### PR DESCRIPTION
Some of the RPC endpoints return  the following error when values for `fromBlock` and `toBlock` are not prefixed with 0x:

```
{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"invalid argument 0: hex string without 0x prefix"}}
```