### PR TITLE
Update contract addresses component to improve multichain clarity

### DIFF
--- a/docs/api/architecture.md
+++ b/docs/api/architecture.md
@@ -6,7 +6,6 @@ vega_network: TESTNET
 
 import Topic from '/docs/topics/_topic-development.mdx'
 import DataNodes from '@site/src/components/DataNodes';
-import EthAddresses from '@site/src/components/EthAddresses';
 
 <Topic />
 

--- a/docs/api/bridge/index.md
+++ b/docs/api/bridge/index.md
@@ -15,7 +15,7 @@ These are the smart contracts that make up the Vega <-> Ethereum interface
 
 Contains the functions necessary to deposit, withdraw, list assets, etc. It is controlled by Multisig Control and controls Asset Pool.
 
-To read more about how the bridge works, [see the Vega ERC20 bridge blog post](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Sepolia on to the Fairground testnet, head over to [Console for Fairground](https://console.fairground.wtf).
+To read more about how the bridge works, see the [Vega ERC20 bridge blog post ↗](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Sepolia on to the Fairground testnet, head over to [Console for Fairground ↗](https://console.fairground.wtf).
 
 ### ERC20 Asset Pool
 <EthAddresses frontMatter={frontMatter} show={["ERC20AssetPool"]} />
@@ -53,14 +53,14 @@ To read more about how the bridge works, [see this blog post ↗](https://blog.v
 Used to control the ownership of bridge contracts, allowing the validators of a Vega network to control which assets can be used with the bridge, and approve asset withdrawals.
 
 ## Arbritrum
-Assets can also be bridged from [Arbitrum](https://arbitrum.io/). The following contracts make up the Vega <-> Arbitrum interface.
+Assets can also be bridged from [Arbitrum ↗](https://arbitrum.io/). The following contracts make up the Vega <-> Arbitrum interface.
 
 ### [Bridge Logic](./interfaces/IERC20_Bridge_Logic.md)
 <EthAddresses frontMatter={frontMatter} show={["ArbitrumBridge"]} />
 
 Contains the functions necessary to deposit, withdraw, list assets, etc. 
 
-To read more about how the bridge works, [see the Vega ERC20 bridge blog post](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Abritrum (sepolia) on to the Fairground testnet, head over to [Console for Fairground](https://console.fairground.wtf).
+To read more about how the bridge works, see the [Vega ERC20 bridge blog post ↗](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Arbitrum (sepolia) on to the Fairground testnet, head over to [Console for Fairground ↗](https://console.fairground.wtf).
 
 ### [Multisig Control](./interfaces/IMultisigControl.md)
 

--- a/docs/api/bridge/index.md
+++ b/docs/api/bridge/index.md
@@ -6,46 +6,64 @@ sidebar_position: 1
 
 import EthAddresses from '@site/src/components/EthAddresses';
 
+
+## Ethereum
 These are the smart contracts that make up the Vega <-> Ethereum interface
 
-## [ERC20 Bridge Logic](./interfaces/IERC20_Bridge_Logic.md)
+### [ERC20 Bridge Logic](./interfaces/IERC20_Bridge_Logic.md)
 <EthAddresses frontMatter={frontMatter} show={["ERC20Bridge"]} />
 
 Contains the functions necessary to deposit, withdraw, list assets, etc. It is controlled by Multisig Control and controls Asset Pool.
 
 To read more about how the bridge works, [see the Vega ERC20 bridge blog post](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Sepolia on to the Fairground testnet, head over to [Console for Fairground](https://console.fairground.wtf).
 
-## ERC20 Asset Pool
+### ERC20 Asset Pool
 <EthAddresses frontMatter={frontMatter} show={["ERC20AssetPool"]} />
 
 Holds deposited assets and remits them to provided addresses based on orders from the assigned Bridge Logic. It is controlled by Bridge Logic and Multisig Control
 
-## [Multisig Control](./interfaces/IMultisigControl.md)
+### [Multisig Control](./interfaces/IMultisigControl.md)
 <EthAddresses frontMatter={frontMatter} show={["MultisigControl"]} />
 
 Handles verification of transactions signed by a threshold of validators. Used to control the ownership of bridge contracts, allowing the validators of a Vega network to control which assets can be used with the bridge, and approve asset withdrawals.
 
-## [Staking Bridge](./interfaces/IStake.md)
+### [Staking Bridge](./interfaces/IStake.md)
 <EthAddresses frontMatter={frontMatter} show={["StakingBridge"]} />
 
 Allows users to deposit and withdraw VEGA tokens for staking. The VEGA tokens are always controlled only by the tokenholder, even when on the Staking Bridge. Stake can be removed at any time by the tokenholder. Note that locked tokens are staked directly from the [vesting contract](#vesting), as they cannot be moved until they are unlocked and redeemed.
 
 For an introduction to staking on Vega, [check out our Concepts section](../../concepts/vega-chain/proof-of-stake.md#bridges-used-for-staking) or for a higher level overview [see this blog post ↗](https://blog.vega.xyz/staking-on-vega-17f22113e3df).
 
-## [ERC20 asset bridge](./interfaces/IERC20_Bridge_Logic.md)
+### [ERC20 asset bridge](./interfaces/IERC20_Bridge_Logic.md)
 <EthAddresses frontMatter={frontMatter} show={["ERC20Bridge"]} />
 
 The ERC20 token smart contract for VEGA token.
 
-## Vesting
+### Vesting
 <EthAddresses frontMatter={frontMatter} show={["VestingBridge"]} />
 
 All VEGA tokens are issued through this. Handles the linear vesting of VEGA tokens and allows users to stake VEGA they hold within the vesting contract, regardless of whether they have already vested or not.
 
 To read more about how the bridge works, [see this blog post ↗](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Sepolia on to the Fairground testnet, head over to [Console for Fairground ↗](https://console.fairground.wtf).
 
-## [Multisig Control](./interfaces/IMultisigControl.md)
+### [Multisig Control](./interfaces/IMultisigControl.md)
 
 <EthAddresses frontMatter={frontMatter} show={["MultisigControl"]} />
+
+Used to control the ownership of bridge contracts, allowing the validators of a Vega network to control which assets can be used with the bridge, and approve asset withdrawals.
+
+## Arbritrum
+Assets can also be bridged from [Arbitrum](https://arbitrum.io/). The following contracts make up the Vega <-> Arbitrum interface.
+
+### [Bridge Logic](./interfaces/IERC20_Bridge_Logic.md)
+<EthAddresses frontMatter={frontMatter} show={["ArbitrumBridge"]} />
+
+Contains the functions necessary to deposit, withdraw, list assets, etc. 
+
+To read more about how the bridge works, [see the Vega ERC20 bridge blog post](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Abritrum (sepolia) on to the Fairground testnet, head over to [Console for Fairground](https://console.fairground.wtf).
+
+### [Multisig Control](./interfaces/IMultisigControl.md)
+
+<EthAddresses frontMatter={frontMatter} show={["ArbitrumMultisigControl"]} />
 
 Used to control the ownership of bridge contracts, allowing the validators of a Vega network to control which assets can be used with the bridge, and approve asset withdrawals.

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -6,7 +6,6 @@ vega_network: TESTNET
 
 import Topic from '/docs/topics/_topic-development.mdx'
 import DataNodes from '@site/src/components/DataNodes';
-import EthAddresses from '@site/src/components/EthAddresses';
 
 <Topic />
 

--- a/docs/tutorials/assets-tokens/staking-tokens.md
+++ b/docs/tutorials/assets-tokens/staking-tokens.md
@@ -104,5 +104,5 @@ With the signature bundle fetched above, the final step is to submit that withdr
 * `nonce` - the nonce from step 4
 * `signatures` - signature bundle from step 4
 
-### Ethereum addresses
+### Important addresses
 <EthAddresses frontMatter={frontMatter} />

--- a/specs/mainnet_contracts.json
+++ b/specs/mainnet_contracts.json
@@ -2,25 +2,31 @@
 	"network": "mainnet",
 	"MultisigControl": {
 		"address": "0xDD2df0E7583ff2acfed5e49Df4a424129cA9B58F",
-		"version": "v2"
+		"version": "v2",
+		"chainId": "1"
 	},
 	"ERC20Bridge": {
 		"address": "0x23872549cE10B40e31D6577e0A920088B0E0666a",
-		"version": "v2"
+		"version": "v2",
+		"chainId": "1"
 	},
 	"ERC20AssetPool": {
 		"address": "0xA226E2A13e07e750EfBD2E5839C5c3Be80fE7D4d",
-		"version": "v1"
+		"version": "v1",
+		"chainId": "1"
 	},
 	"StakingBridge": {
 		"address": "0x195064D33f09e0c42cF98E665D9506e0dC17de68",
-		"version": "v1"
+		"version": "v1",
+		"chainId": "1"
 	},
 	"VestingBridge": {
 		"address": "0x23d1bFE8fA50a167816fBD79D7932577c06011f4",
-		"version": "v1"
+		"version": "v1",
+		"chainId": "1"
 	},
 	"VegaToken": {
-		"address": "0xcB84d72e61e383767C4DFEb2d8ff7f4FB89abc6e"
+		"address": "0xcB84d72e61e383767C4DFEb2d8ff7f4FB89abc6e",
+		"chainId": "1"
 	}
 }

--- a/specs/mainnet_contracts.json
+++ b/specs/mainnet_contracts.json
@@ -28,5 +28,13 @@
 	"VegaToken": {
 		"address": "0xcB84d72e61e383767C4DFEb2d8ff7f4FB89abc6e",
 		"chainId": "1"
+	},
+	"ArbitrumMultisigControl": {
+		"address": "0x348372DE65Ca7F2567FE267ccc4D1bF6d4b71f6F",
+		"chainId": "42161"
+	},
+	"ArbitrumBridge": {
+ 		"address": "0x475B597652bCb2769949FD6787b1DC6916518407",
+		"chainId": "42161"
 	}
 }

--- a/specs/testnet_contracts.json
+++ b/specs/testnet_contracts.json
@@ -35,5 +35,13 @@
 		"version": "TokenBase",
 		"minter": "0x3c9BCb0B5BE9D1c4D75024BAA0d5D55aD354fa77",
 		"chainId": "11155111"
+	},
+	"ArbitrumMultisigControl": {
+		"address": "0x752faCb1e1EEf7A5a154db5Bf54988E80b0e96Da",
+		"chainId": "421614"
+	},
+	"ArbitrumBridge": {
+ 		"address": "0x927067717B0A9bd553fC421Ae63b3377694b4166",
+		"chainId": "421614"
 	}
 }

--- a/specs/testnet_contracts.json
+++ b/specs/testnet_contracts.json
@@ -1,33 +1,39 @@
 {
-	"network": "sepolia",
 	"MultisigControl": {
 		"address": "0x6eBc32d66277D94DB8FF2ccF86E36f37F29a52D3",
-		"version": "v2"
+		"version": "v2",
+		"chainId": "11155111"
 	},
 	"ERC20Bridge": {
 		"address": "0x7fe27d970bc8Afc3B11Cc8d9737bfB66B1efd799",
-		"version": "v2"
+		"version": "v2",
+		"chainId": "11155111"
 	},
 	"ERC20AssetPool": {
 		"address": "0x2Fe022FFcF16B515A13077e53B0a19b3e3447855",
-		"version": "v1"
+		"version": "v1",
+		"chainId": "11155111"
 	},
 	"StakingBridge": {
 		"address": "0xFFb0A0d4806502ceF491aF1141f66669A1Bd0D03",
-		"version": "v1"
+		"version": "v1",
+		"chainId": "11155111"
 	},
 	"VestingBridge": {
 		"address": "0x680fF88252FA7071CAce7398e77872d54D781d0B",
-		"version": "v1"
+		"version": "v1",
+		"chainId": "11155111"
 	},
 	"VegaToken": {
 		"address": "0xdf1B0F223cb8c7aB3Ef8469e529fe81E73089BD9",
 		"version": "TokenBase",
-		"minter": "0x3c9BCb0B5BE9D1c4D75024BAA0d5D55aD354fa77"
+		"minter": "0x3c9BCb0B5BE9D1c4D75024BAA0d5D55aD354fa77",
+		"chainId": "11155111"
 	},
 	"V1Token": {
 		"address": "0xB6943f22FfeB615C420911B38561b27718C91845",
 		"version": "TokenBase",
-		"minter": "0x3c9BCb0B5BE9D1c4D75024BAA0d5D55aD354fa77"
+		"minter": "0x3c9BCb0B5BE9D1c4D75024BAA0d5D55aD354fa77",
+		"chainId": "11155111"
 	}
 }

--- a/src/components/EthAddresses.js
+++ b/src/components/EthAddresses.js
@@ -3,10 +3,16 @@ import mainnetContracts from "../../specs/mainnet_contracts.json";
 import testnetContracts from "../../specs/testnet_contracts.json";
 
 const etherscanBase = {
-  ropsten: "https://ropsten.etherscan.io/address/",
-  sepolia: "https://sepolia.etherscan.io/address/",
-  mainnet: "https://etherscan.io/address/",
+  "11155111": "https://sepolia.etherscan.io/address/",
+  "1": "https://etherscan.io/address/",
 };
+
+const networkName = {
+  "11155111": "Ethereum (Sepolia)",
+  "1": "Ethereum Mainnet",
+  "42161": "Arbitrum",
+  "421614": "Arbitrum (Sepolia)"
+}
 
 // Budget version of frontend-monorepo's EtherscanLink
 function etherscanLink(contractAddress, network) {
@@ -54,7 +60,6 @@ export default function EthAddresses({ frontMatter, show }) {
   }
 
   const addresses = vega_network.toLowerCase() === 'mainnet' ? mainnetContracts : testnetContracts
-  const ethereum_network = addresses.network
 
   if (!addresses) {
     throw new Error("Could not load addresses");
@@ -66,7 +71,7 @@ export default function EthAddresses({ frontMatter, show }) {
         <tr>
           <th>Name</th>
           <th>Address</th>
-          <th>Ethereum network</th>
+          <th>Network</th>
         </tr>
       </thead>
       <tbody>
@@ -77,16 +82,17 @@ export default function EthAddresses({ frontMatter, show }) {
             }
           )
           .map((key) => {
+            const contract = addresses[key]
             return (
               <tr>
                 <td>
                   <strong>{contractNames[key]}</strong>
                 </td>
                 <td>
-                  <code>{addresses[key].address}</code>{" "}
-                  {etherscanLink(addresses[key].address, ethereum_network)}
+                  <code>{contract.address}</code>{" "}
+                  {etherscanLink(contract.address, contract.chainId)}
                 </td>
-                <td align="center">{ethereum_network}</td>
+                <td align="center">{networkName[contract.chainId]}</td>
               </tr>
             );
           })}

--- a/src/components/EthAddresses.js
+++ b/src/components/EthAddresses.js
@@ -5,11 +5,13 @@ import testnetContracts from "../../specs/testnet_contracts.json";
 const etherscanBase = {
   "11155111": "https://sepolia.etherscan.io/address/",
   "1": "https://etherscan.io/address/",
+  "42161": "https://arbiscan.io/address/",
+  "421614": "https://sepolia.arbiscan.io/address/",
 };
 
 const networkName = {
   "11155111": "Ethereum (Sepolia)",
-  "1": "Ethereum Mainnet",
+  "1": "Ethereum",
   "42161": "Arbitrum",
   "421614": "Arbitrum (Sepolia)"
 }
@@ -34,7 +36,9 @@ const contractNames = {
   VegaToken: "Vega token",
   VestingBridge: "Token vesting",
   StakingBridge: "Staking bridge",
-  ERC20Bridge: "ERC20 Bridge",
+  ERC20Bridge: "Ethereum ERC20 Bridge",
+  ArbitrumMultisigControl: "Arbitrum Multisig Control",
+  ArbitrumBridge: "Arbitrum Bridge",
 };
 
 const showOnlyDefault = [
@@ -42,6 +46,7 @@ const showOnlyDefault = [
   "VestingBridge",
   "StakingBridge",
   "ERC20Bridge",
+  "ArbitrumBridge"
 ];
 
 /**

--- a/versioned_docs/version-v0.76/api/bridge/index.md
+++ b/versioned_docs/version-v0.76/api/bridge/index.md
@@ -59,7 +59,7 @@ Assets can also be bridged from [Arbitrum ↗](https://arbitrum.io/). The follow
 
 Contains the functions necessary to deposit, withdraw, list assets, etc. 
 
-To read more about how the bridge works, [see the Vega ERC20 bridge blog post](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Abritrum (sepolia) on to the Fairground testnet, head over to [Console for Fairground](https://console.fairground.wtf).
+To read more about how the bridge works, see the [Vega ERC20 bridge blog post ↗](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Arbitrum (sepolia) on to the Fairground testnet, head over to [Console for Fairground ↗](https://console.fairground.wtf).
 
 ### [Multisig Control](./interfaces/IMultisigControl.md)
 

--- a/versioned_docs/version-v0.76/api/bridge/index.md
+++ b/versioned_docs/version-v0.76/api/bridge/index.md
@@ -6,46 +6,63 @@ sidebar_position: 1
 
 import EthAddresses from '@site/src/components/EthAddresses';
 
+## Ethereum
 These are the smart contracts that make up the Vega <-> Ethereum interface
 
-## [ERC20 Bridge Logic](./interfaces/IERC20_Bridge_Logic.md)
+### [ERC20 Bridge Logic](./interfaces/IERC20_Bridge_Logic.md)
 <EthAddresses frontMatter={frontMatter} show={["ERC20Bridge"]} />
 
 Contains the functions necessary to deposit, withdraw, list assets, etc. It is controlled by Multisig Control and controls Asset Pool.
 
 To read more about how the bridge works, [see the Vega ERC20 bridge blog post](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2).
 
-## ERC20 Asset Pool
+### ERC20 Asset Pool
 <EthAddresses frontMatter={frontMatter} show={["ERC20AssetPool"]} />
 
 Holds deposited assets and remits them to provided addresses based on orders from the assigned Bridge Logic. It is controlled by Bridge Logic and Multisig Control
 
-## [Multisig Control](./interfaces/IMultisigControl.md)
+### [Multisig Control](./interfaces/IMultisigControl.md)
 <EthAddresses frontMatter={frontMatter} show={["MultisigControl"]} />
 
 Handles verification of transactions signed by a threshold of validators. Used to control the ownership of bridge contracts, allowing the validators of a Vega network to control which assets can be used with the bridge, and approve asset withdrawals.
 
-## [Staking Bridge](./interfaces/IStake.md)
+### [Staking Bridge](./interfaces/IStake.md)
 <EthAddresses frontMatter={frontMatter} show={["StakingBridge"]} />
 
 Allows users to deposit and withdraw VEGA tokens for staking. The VEGA tokens are always controlled only by the tokenholder, even when on the Staking Bridge. Stake can be removed at any time by the tokenholder. Note that locked tokens are staked directly from the [vesting contract](#vesting), as they cannot be moved until they are unlocked and redeemed.
 
 For an introduction to staking on Vega, [check out our Concepts section](../../concepts/vega-chain/proof-of-stake.md#bridges-used-for-staking) or for a higher level overview [see this blog post ↗](https://blog.vega.xyz/staking-on-vega-17f22113e3df).
 
-## [ERC20 asset bridge](./interfaces/IERC20_Bridge_Logic.md)
+### [ERC20 asset bridge](./interfaces/IERC20_Bridge_Logic.md)
 <EthAddresses frontMatter={frontMatter} show={["ERC20Bridge"]} />
 
 The ERC20 token smart contract for VEGA token.
 
-## Vesting
+### Vesting
 <EthAddresses frontMatter={frontMatter} show={["VestingBridge"]} />
 
 All VEGA tokens are issued through this. Handles the linear vesting of VEGA tokens and allows users to stake VEGA they hold within the vesting contract, regardless of whether they have already vested or not.
 
 To read more about how the bridge works, [see this blog post ↗](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2).
 
-## [Multisig Control](./interfaces/IMultisigControl.md)
+### [Multisig Control](./interfaces/IMultisigControl.md)
 
 <EthAddresses frontMatter={frontMatter} show={["MultisigControl"]} />
+
+Used to control the ownership of bridge contracts, allowing the validators of a Vega network to control which assets can be used with the bridge, and approve asset withdrawals.
+
+## Arbritrum
+Assets can also be bridged from [Arbitrum](https://arbitrum.io/). The following contracts make up the Vega <-> Arbitrum interface.
+
+### [Bridge Logic](./interfaces/IERC20_Bridge_Logic.md)
+<EthAddresses frontMatter={frontMatter} show={["ArbitrumBridge"]} />
+
+Contains the functions necessary to deposit, withdraw, list assets, etc. 
+
+To read more about how the bridge works, [see the Vega ERC20 bridge blog post](https://blog.vega.xyz/vega-erc20-bridge-331a5235efa2). If you're looking for a way to deposit tokens from Abritrum (sepolia) on to the Fairground testnet, head over to [Console for Fairground](https://console.fairground.wtf).
+
+### [Multisig Control](./interfaces/IMultisigControl.md)
+
+<EthAddresses frontMatter={frontMatter} show={["ArbitrumMultisigControl"]} />
 
 Used to control the ownership of bridge contracts, allowing the validators of a Vega network to control which assets can be used with the bridge, and approve asset withdrawals.

--- a/versioned_docs/version-v0.76/api/bridge/index.md
+++ b/versioned_docs/version-v0.76/api/bridge/index.md
@@ -52,7 +52,7 @@ To read more about how the bridge works, [see this blog post ↗](https://blog.v
 Used to control the ownership of bridge contracts, allowing the validators of a Vega network to control which assets can be used with the bridge, and approve asset withdrawals.
 
 ## Arbritrum
-Assets can also be bridged from [Arbitrum](https://arbitrum.io/). The following contracts make up the Vega <-> Arbitrum interface.
+Assets can also be bridged from [Arbitrum ↗](https://arbitrum.io/). The following contracts make up the Vega <-> Arbitrum interface.
 
 ### [Bridge Logic](./interfaces/IERC20_Bridge_Logic.md)
 <EthAddresses frontMatter={frontMatter} show={["ArbitrumBridge"]} />

--- a/versioned_docs/version-v0.76/tutorials/assets-tokens/staking-tokens.md
+++ b/versioned_docs/version-v0.76/tutorials/assets-tokens/staking-tokens.md
@@ -104,5 +104,5 @@ With the signature bundle fetched above, the final step is to submit that withdr
 * `nonce` - the nonce from step 4
 * `signatures` - signature bundle from step 4
 
-### Ethereum addresses
+### Important addresses
 <EthAddresses frontMatter={frontMatter} />


### PR DESCRIPTION
# Changes
- [x] Update EthAddresses component to support `chainId` per contract
- [x] Add `chainId` -> network name mappings
- [x] Add Arbitrum & Arbitrum testnet explorer links
- [x] Update table column from 'Ethereum network' to 'Network'
- [x] Update all chain names to include Ethereum/Arbitrum where required
- [x] Add mainnet & testnet Arbitrum contract addresses
- [x] Update Ethereum Bridges & Contracts page to reference aribtrum contracts

# Todo
- [x] Rename Ethereum Bridges and Contracts page to make sense
  - Suggestion: 'Bridges & Contracts'
- [x] Rebase after merging #1055  